### PR TITLE
スタイル調整・目次見出し追従機能追加

### DIFF
--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,0 +1,26 @@
+name: Prettier
+
+on:
+  push:
+    branches:
+      - main
+      - 010-adjust-styles
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+
+      - name: Run Prettier
+        run: npx prettier --write "**/*.{js,jsx,ts,tsx,json}"
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Prettier

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -1,10 +1,9 @@
-name: Prettier
+name: Auto Prettier
 
 on:
   push:
     branches:
       - main
-      - 010-adjust-styles
 
 jobs:
   format:
@@ -23,5 +22,4 @@ jobs:
 
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          commit_message: Prettier
-
+          commit_message: Auto Prettier

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -24,3 +24,4 @@ jobs:
       - uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Prettier
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,4 @@
 package.json
 package-lock.json
 public
+content

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,4 @@
 {
-  "arrowParens": "avoid",
+  "quoteProps": "preserve",
   "semi": false
 }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,6 +1,6 @@
-const path = require('path')
+const path = require("path")
 
-const contentPath = path.resolve(process.env.CONTENT_PATH || 'content')
+const contentPath = path.resolve(process.env.CONTENT_PATH || "content")
 
 console.debug(`CONTENT_PATH - ${contentPath}`)
 console.debug(`PATH_PREFIX - ${process.env.PATH_PREFIX}`)
@@ -12,7 +12,7 @@ const {
   SITE_DESCRIPTION,
   MANIFEST_BG_COLOR,
   MANIFEST_THEME_COLOR,
-} = require('./site-config')
+} = require("./site-config")
 
 const plugins = [
   `gatsby-plugin-image`,
@@ -28,10 +28,7 @@ const plugins = [
     options: {
       path: contentPath,
       name: `blog`,
-      ignore: [
-        `${contentPath}/*.md`,
-        `${contentPath}/.draft/**/*`,
-      ],
+      ignore: [`${contentPath}/*.md`, `${contentPath}/.draft/**/*`],
     },
   },
   {
@@ -58,15 +55,15 @@ const plugins = [
           },
         },
         `gatsby-remark-autolink-headers`,
-        'gatsby-remark-prismjs-title',
+        "gatsby-remark-prismjs-title",
         {
           resolve: `gatsby-remark-prismjs`,
           options: {
             classPrefix: "language-",
             aliases: {
-              'xaml': 'xml',
-              'sh': 'bash',
-              'ps': 'powershell',
+              "xaml": "xml",
+              "sh": "bash",
+              "ps": "powershell",
             },
           },
         },
@@ -95,7 +92,7 @@ const plugins = [
       feeds: [
         {
           serialize: ({ query: { site, allMarkdownRemark } }) => {
-            return allMarkdownRemark.nodes.map(node => {
+            return allMarkdownRemark.nodes.map((node) => {
               return Object.assign({}, node.frontmatter, {
                 description: node.excerpt,
                 date: node.frontmatter.date,
@@ -147,8 +144,8 @@ const plugins = [
   {
     resolve: "gatsby-plugin-anchor-links",
     options: {
-      offset: -100
-    }
+      offset: -100,
+    },
   },
   // this (optional) plugin enables Progressive Web App + Offline functionality
   // To learn more, visit: https://gatsby.dev/offline

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,14 +1,14 @@
 "use strict"
 
-const fs = require('fs');
-const gracefulFs = require('graceful-fs');
-gracefulFs.gracefulify(fs);
+const fs = require("fs")
+const gracefulFs = require("graceful-fs")
+gracefulFs.gracefulify(fs)
 
 require("ts-node").register({
   compilerOptions: {
     module: "commonjs",
     target: "esnext",
-    baseUrl: "src"
+    baseUrl: "src",
   },
 })
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "build": "gatsby build",
     "dev": "gatsby develop",
     "dev-verbose": "gatsby develop --verbose",
-    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json,md}\"",
+    "format": "prettier --write \"**/*.{js,jsx,ts,tsx,json}\"",
     "start": "npm run develop",
     "serve": "gatsby serve",
     "clean": "gatsby clean",

--- a/site-config.js
+++ b/site-config.js
@@ -1,7 +1,7 @@
 module.exports = {
-  SITE_NAME: 'MSeeeeN',
-  SITE_URL: 'https://mseeeen.msen.jp/',
-  SITE_DESCRIPTION: '大阪発 IT メディア by MSEN',
+  SITE_NAME: "MSeeeeN",
+  SITE_URL: "https://mseeeen.msen.jp/",
+  SITE_DESCRIPTION: "大阪発 IT メディア by MSEN",
   MANIFEST_BG_COLOR: `#ffffff`,
   MANIFEST_THEME_COLOR: `#1577e7`,
 }

--- a/src/components/author-link/index.tsx
+++ b/src/components/author-link/index.tsx
@@ -1,5 +1,10 @@
 import * as React from "react"
-import { GatsbyImage, getImage, IGatsbyImageData, StaticImage } from "gatsby-plugin-image"
+import {
+  GatsbyImage,
+  getImage,
+  IGatsbyImageData,
+  StaticImage,
+} from "gatsby-plugin-image"
 import * as styles from "./index.module.css"
 
 type Props = {
@@ -7,32 +12,37 @@ type Props = {
   github: string
   avatarImage: IGatsbyImageData
   reverse?: boolean
-};
+}
 
 export default function AuthorLink(props: Props) {
-  const github = props.github;
-  const name = props.name || props.github;
+  const github = props.github
+  const name = props.name || props.github
   const avatarImage = getImage(props.avatarImage)
 
   return (
-    <div className={`author-link ${styles.container} ${props.reverse ? styles.reverse : ''}`}>
-      { props.reverse ? <div>{name}</div> : null }
-      { avatarImage
-        ? <GatsbyImage
-            image={avatarImage}
-            className={styles.avatar}
-            alt={github}
-            />
-        : <StaticImage
-            src="https://www.gravatar.com/avatar/?d=mp&s=50"
-            className={styles.avatar}
-            width={25}
-            height={25}
-            layout="fixed"
-            alt={`${github} - GitHub`}
-            />
-      }
-      { !props.reverse ? <div>{name}</div> : null }
+    <div
+      className={`author-link ${styles.container} ${
+        props.reverse ? styles.reverse : ""
+      }`}
+    >
+      {props.reverse ? <div>{name}</div> : null}
+      {avatarImage ? (
+        <GatsbyImage
+          image={avatarImage}
+          className={styles.avatar}
+          alt={github}
+        />
+      ) : (
+        <StaticImage
+          src="https://www.gravatar.com/avatar/?d=mp&s=50"
+          className={styles.avatar}
+          width={25}
+          height={25}
+          layout="fixed"
+          alt={`${github} - GitHub`}
+        />
+      )}
+      {!props.reverse ? <div>{name}</div> : null}
     </div>
   )
 }

--- a/src/components/bio/index.module.css
+++ b/src/components/bio/index.module.css
@@ -14,11 +14,14 @@
   border-radius: 100%;
 }
 
+.bio .main {
+  flex: 1;
+}
+
 .bio .nameInfo {
   display: flex;
   align-items: center;
   margin-bottom: var(--spacing-2);
-  margin-right: var(--spacing-2);
 }
 
 .bio .nameInfo a {
@@ -30,10 +33,6 @@
 
 .bio .nameInfo a span {
   margin-left: var(--spacing-1);
-}
-
-.bio .bioText {
-  line-height: var(--lineHeight-tight);
 }
 
 

--- a/src/components/bio/index.tsx
+++ b/src/components/bio/index.tsx
@@ -17,24 +17,24 @@ const Bio = (props: Props) => {
   const avatarImage = getImage(props.avatarImage)
 
   return (
-    <div className={styles.bio}>
+    <div className={`${styles.bio} bio`}>
       {avatarImage
         ? <GatsbyImage
           image={avatarImage}
-          className={styles.avatar}
+          className={`${styles.avatar} bio-avatar`}
           alt={github}
         />
         : <StaticImage
           src="https://www.gravatar.com/avatar/?d=mp&s=50"
-          className={styles.avatar}
+          className={`${styles.avatar} bio-avatar`}
           width={50}
           height={50}
           layout="fixed"
           alt={`${github} - GitHub`}
         />
       }
-      <div>
-        <div className={styles.nameInfo}>
+      <div className={`${styles.main} bio-main`}>
+        <div className={`${styles.nameInfo} bio-name-info`}>
           <strong>{name}</strong>
           <a href={githubUrl} target="_blank" rel="noreferrer" title={github}>
             <StaticImage
@@ -47,7 +47,7 @@ const Bio = (props: Props) => {
             <span>{github}</span>
           </a>
         </div>
-        <p className={styles.bioText}>{bio}</p>
+        <p className={`${styles.bioText} bio-bio-text`}>{bio}</p>
       </div>
     </div>
   )

--- a/src/components/bio/index.tsx
+++ b/src/components/bio/index.tsx
@@ -1,5 +1,10 @@
 import * as React from "react"
-import { GatsbyImage, getImage, IGatsbyImageData, StaticImage } from "gatsby-plugin-image"
+import {
+  GatsbyImage,
+  getImage,
+  IGatsbyImageData,
+  StaticImage,
+} from "gatsby-plugin-image"
 import * as styles from "./index.module.css"
 
 type Props = {
@@ -7,24 +12,25 @@ type Props = {
   github: string
   name: string
   avatarImage: IGatsbyImageData
-};
+}
 
 const Bio = (props: Props) => {
-  const bio = props.bio || null;
-  const github = props.github;
-  const name = props.name || '名無しの権兵衛';
-  const githubUrl = `https://github.com/${github}`;
+  const bio = props.bio || null
+  const github = props.github
+  const name = props.name || "名無しの権兵衛"
+  const githubUrl = `https://github.com/${github}`
   const avatarImage = getImage(props.avatarImage)
 
   return (
     <div className={`${styles.bio} bio`}>
-      {avatarImage
-        ? <GatsbyImage
+      {avatarImage ? (
+        <GatsbyImage
           image={avatarImage}
           className={`${styles.avatar} bio-avatar`}
           alt={github}
         />
-        : <StaticImage
+      ) : (
+        <StaticImage
           src="https://www.gravatar.com/avatar/?d=mp&s=50"
           className={`${styles.avatar} bio-avatar`}
           width={50}
@@ -32,7 +38,7 @@ const Bio = (props: Props) => {
           layout="fixed"
           alt={`${github} - GitHub`}
         />
-      }
+      )}
       <div className={`${styles.main} bio-main`}>
         <div className={`${styles.nameInfo} bio-name-info`}>
           <strong>{name}</strong>

--- a/src/components/breadcrumb-list/index.tsx
+++ b/src/components/breadcrumb-list/index.tsx
@@ -1,5 +1,5 @@
-import { Link } from "gatsby";
-import React from "react";
+import { Link } from "gatsby"
+import React from "react"
 import * as styles from "./index.module.css"
 
 export type BreadcrumbListItem = {
@@ -13,28 +13,30 @@ type Props = {
 }
 
 export default function BreadcrumbList(props: Props) {
-
   function createListItem(item: BreadcrumbListItem, position: number) {
     return (
       <li
         key={`breadcrumb-list-item-${position}`}
         itemProp="itemListElement"
         itemScope
-        itemType="https://schema.org/ListItem">
-        {!item.current && item.url
-          ? <Link
-              itemProp="item"
-              to={item.url}
-              itemScope itemType="https://schema.org/WebPage"
-              itemID={item.url}
-            >
+        itemType="https://schema.org/ListItem"
+      >
+        {!item.current && item.url ? (
+          <Link
+            itemProp="item"
+            to={item.url}
+            itemScope
+            itemType="https://schema.org/WebPage"
+            itemID={item.url}
+          >
             <span itemProp="name">{item.name}</span>
           </Link>
-          : <span itemProp="name">{item.name}</span>
-        }
+        ) : (
+          <span itemProp="name">{item.name}</span>
+        )}
         <meta itemProp="position" content={`${position}`} />
       </li>
-    );
+    )
   }
   return (
     <div className={`breadcrumb-list ${styles.breadcrumbList}`}>
@@ -42,5 +44,5 @@ export default function BreadcrumbList(props: Props) {
         {props.items.map((x, i) => createListItem(x, i + 1))}
       </ol>
     </div>
-  );
+  )
 }

--- a/src/components/jump-button/index.tsx
+++ b/src/components/jump-button/index.tsx
@@ -1,43 +1,47 @@
-import React, { createRef, useEffect } from "react";
-import { useState } from "react";
+import React, { createRef, useEffect } from "react"
+import { useState } from "react"
 import * as styles from "./index.module.css"
 
 export default function JumpButton() {
-
-  const [toBottom, setToBottom] = useState(true);
-  const buttonRef = createRef<HTMLButtonElement>();
+  const [toBottom, setToBottom] = useState(true)
+  const buttonRef = createRef<HTMLButtonElement>()
 
   useEffect(() => {
     const onButtonClick = (e: any) => {
-      const pos = (window.scrollY > window.innerHeight)
-        ? { top: 0, left: 0 }
-        : { top: window.document.body.scrollHeight || 99999, left: 0 };
+      const pos =
+        window.scrollY > window.innerHeight
+          ? { top: 0, left: 0 }
+          : { top: window.document.body.scrollHeight || 99999, left: 0 }
       window.scrollTo({
         ...pos,
-        behavior: 'smooth'
-      });
+        behavior: "smooth",
+      })
       e.preventDefault()
-    };
-  
-    const onScroll = () => {
-      setToBottom(() => (window.pageYOffset || document.documentElement.scrollTop) < window.innerHeight);
-    };
-
-    buttonRef.current?.addEventListener('click', onButtonClick)
-    document.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      buttonRef.current?.removeEventListener('click', onButtonClick)
-      document.removeEventListener('scroll', onScroll)
     }
-  }, []);
+
+    const onScroll = () => {
+      setToBottom(
+        () =>
+          (window.pageYOffset || document.documentElement.scrollTop) <
+          window.innerHeight
+      )
+    }
+
+    buttonRef.current?.addEventListener("click", onButtonClick)
+    document.addEventListener("scroll", onScroll, { passive: true })
+    return () => {
+      buttonRef.current?.removeEventListener("click", onButtonClick)
+      document.removeEventListener("scroll", onScroll)
+    }
+  }, [])
 
   return (
     <div className={`jump-button ${styles.container}`}>
       <button
         ref={buttonRef}
         type="button"
-        className={`${styles.button} ${(toBottom ? styles.toBottom : '')}`}
+        className={`${styles.button} ${toBottom ? styles.toBottom : ""}`}
       />
     </div>
-  );
+  )
 }

--- a/src/components/jump-button/index.tsx
+++ b/src/components/jump-button/index.tsx
@@ -1,6 +1,5 @@
-import React, { createRef, useEffect, useRef } from "react";
+import React, { createRef, useEffect } from "react";
 import { useState } from "react";
-import { useCallback } from "react";
 import * as styles from "./index.module.css"
 
 export default function JumpButton() {

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -16,7 +16,11 @@ const Layout = ({ location, title, children }: Props) => {
   const rootPath = `${__PATH_PREFIX__}/`
   const isRootPath = location.pathname === rootPath
 
-  const { site: { siteMetadata: { title: siteTitle } } } = useStaticQuery(
+  const {
+    site: {
+      siteMetadata: { title: siteTitle },
+    },
+  } = useStaticQuery(
     graphql`
       query {
         site {
@@ -27,7 +31,7 @@ const Layout = ({ location, title, children }: Props) => {
       }
     `
   )
-  
+
   const headerLogo = (
     <>
       <StaticImage
@@ -74,10 +78,13 @@ const Layout = ({ location, title, children }: Props) => {
           <ThemeSwitcher
             settingKey={`${siteTitle}_theme`}
             tooltip={`ダークテーマ/ライトテーマ切り替え`}
-            />
+          />
         </div>
       </div>
-      <div className={isRootPath ? '' : `global-wrapper`} data-is-root-path={isRootPath}>
+      <div
+        className={isRootPath ? "" : `global-wrapper`}
+        data-is-root-path={isRootPath}
+      >
         {children}
       </div>
       <footer>

--- a/src/components/more-link/index.tsx
+++ b/src/components/more-link/index.tsx
@@ -7,11 +7,11 @@ type Props = {
 }
 
 export default function MoreLink(props: Props) {
-  const label = props.label || 'もっと見る'
+  const label = props.label || "もっと見る"
 
   return (
     <Link to={props.to} className={`more-link button`}>
-      { label }
+      {label}
     </Link>
   )
 }

--- a/src/components/page-footer/index.tsx
+++ b/src/components/page-footer/index.tsx
@@ -1,8 +1,7 @@
 import * as React from "react"
 import { StaticImage } from "gatsby-plugin-image"
 
-type Props = {
-}
+type Props = {}
 
 const logoImage = (
   <>
@@ -11,20 +10,17 @@ const logoImage = (
       width={240}
       layout="fixed"
       placeholder="none"
-      alt={''}
+      alt={""}
     />
   </>
 )
 
 export default function PageFooter(props: Props) {
-
   return (
     <div className={`page-footer`}>
-      <div className={`page-footer-logo`}>
-        { logoImage }
-      </div>
+      <div className={`page-footer-logo`}>{logoImage}</div>
       <div className={`page-footer-copyright`}>
-          MSeeeeN © {new Date().getFullYear()}, MSEN Inc.
+        MSeeeeN © {new Date().getFullYear()}, MSEN Inc.
       </div>
     </div>
   )

--- a/src/components/paginator/index.tsx
+++ b/src/components/paginator/index.tsx
@@ -1,64 +1,68 @@
-import { Link } from "gatsby";
-import React from "react";
-import { PageContext } from "types/pagination";
+import { Link } from "gatsby"
+import React from "react"
+import { PageContext } from "types/pagination"
 
 type Props = {
   pathPrefix: string
   context: PageContext
-};
-
-export default function Paginator({ pathPrefix, context }: Props) {
-
-  if (context.numberOfPages === 1) return null;
-
-  const numbers = insertFiller(createPageNumbers(context.numberOfPages, context.humanPageNumber))
-
-  const links = numbers
-    .map(n =>
-      !n
-      ? <>
-          <span
-            key={`paginator-${n}`}
-            className={`paginator-ellipse`} />
-        </>
-      : (
-        n === context.humanPageNumber
-        ? <span key={`paginator-${n}`} className={`paginator-link paginator-link-current`}>
-            <span>{n}</span>
-          </span>
-        : <span key={`paginator-${n}`} className={`paginator-link`}>
-            <Link to={n === 1 ? pathPrefix : `${pathPrefix.replace(/\/$/, '')}/${n}`}>
-              {n}
-            </Link>
-          </span>
-      )
-    );
-
-  return (
-    <div className={`paginator`}>
-      {links}
-    </div>
-  )
 }
 
-function createPageNumbers(numberOfPages: number, currentPage: number): number[] {
+export default function Paginator({ pathPrefix, context }: Props) {
+  if (context.numberOfPages === 1) return null
 
+  const numbers = insertFiller(
+    createPageNumbers(context.numberOfPages, context.humanPageNumber)
+  )
+
+  const links = numbers.map((n) =>
+    !n ? (
+      <>
+        <span key={`paginator-${n}`} className={`paginator-ellipse`} />
+      </>
+    ) : n === context.humanPageNumber ? (
+      <span
+        key={`paginator-${n}`}
+        className={`paginator-link paginator-link-current`}
+      >
+        <span>{n}</span>
+      </span>
+    ) : (
+      <span key={`paginator-${n}`} className={`paginator-link`}>
+        <Link
+          to={n === 1 ? pathPrefix : `${pathPrefix.replace(/\/$/, "")}/${n}`}
+        >
+          {n}
+        </Link>
+      </span>
+    )
+  )
+
+  return <div className={`paginator`}>{links}</div>
+}
+
+function createPageNumbers(
+  numberOfPages: number,
+  currentPage: number
+): number[] {
   if (numberOfPages <= 5) {
-    return [...new Array(numberOfPages)].map((_, n) => n + 1);
+    return [...new Array(numberOfPages)].map((_, n) => n + 1)
   }
 
-  const numbers =
-    [...new Set([
-      1, // first
-      numberOfPages, // last
-      currentPage,
-      currentPage + 1,
-      currentPage - 1,
-      currentPage + 2,
-      currentPage - 2,
-      currentPage + 3,
-      currentPage - 3,
-    ].filter(n => n >= 1 && n <= numberOfPages))].splice(0, 5)
+  const numbers = [
+    ...new Set(
+      [
+        1, // first
+        numberOfPages, // last
+        currentPage,
+        currentPage + 1,
+        currentPage - 1,
+        currentPage + 2,
+        currentPage - 2,
+        currentPage + 3,
+        currentPage - 3,
+      ].filter((n) => n >= 1 && n <= numberOfPages)
+    ),
+  ].splice(0, 5)
 
   numbers.sort((a, b) => a - b)
 

--- a/src/components/post-card-list/index.tsx
+++ b/src/components/post-card-list/index.tsx
@@ -1,15 +1,16 @@
-import React from "react";
-import PostCard, { PostSummary } from "components/post-card";
+import React from "react"
+import PostCard, { PostSummary } from "components/post-card"
 
 type Props = {
-  posts: PostSummary[];
-};
+  posts: PostSummary[]
+}
 
 export default function PostCardList({ posts }: Props) {
-
   return (
     <div className="post-card-list">
-      {posts.map((post: PostSummary) => <PostCard key={`post-card-${post.id}`} post={post} />)}
+      {posts.map((post: PostSummary) => (
+        <PostCard key={`post-card-${post.id}`} post={post} />
+      ))}
     </div>
-  );
+  )
 }

--- a/src/components/post-card/index.tsx
+++ b/src/components/post-card/index.tsx
@@ -1,9 +1,9 @@
-import React from "react";
-import { graphql, Link } from "gatsby";
-import { getImage, GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image";
+import React from "react"
+import { graphql, Link } from "gatsby"
+import { getImage, GatsbyImage, IGatsbyImageData } from "gatsby-plugin-image"
 
-import AuthorLink from "components/author-link";
-import TagList from "components/tag-list";
+import AuthorLink from "components/author-link"
+import TagList from "components/tag-list"
 
 import * as styles from "./index.module.css"
 
@@ -25,12 +25,12 @@ export type PostSummary = {
     slug: string
     heroImage?: IGatsbyImageData
   }
-};
+}
 
 type Props = {
-  post: PostSummary;
+  post: PostSummary
   showDescription?: boolean
-};
+}
 
 export const query = graphql`
   fragment PostSummary on MarkdownRemark {
@@ -63,9 +63,12 @@ export const query = graphql`
 `
 
 export default function PostCard({ post, showDescription }: Props) {
-
-  const heroImage = post.fields.heroImage ? getImage(post.fields.heroImage) : null;
-  const avatarImage = post.frontmatter.avatarImage ? getImage(post.frontmatter.avatarImage) : null;
+  const heroImage = post.fields.heroImage
+    ? getImage(post.fields.heroImage)
+    : null
+  const avatarImage = post.frontmatter.avatarImage
+    ? getImage(post.frontmatter.avatarImage)
+    : null
   const description = showDescription
     ? post.frontmatter.description || post.excerpt
     : null
@@ -73,47 +76,45 @@ export default function PostCard({ post, showDescription }: Props) {
     <div className="post-card">
       <div className="post-card-hero">
         <Link to={post.fields.slug}>
-          { heroImage
-            ? <GatsbyImage
-                image={heroImage}
-                alt={post.frontmatter.title}
-                />
-            : <div className={`post-hero-placeholder ${styles.postHeroPlaceholder}`}>
-                <span>{post.frontmatter.tags?.[0] || post.frontmatter.author?.id || ''}</span>
-              </div>
-          }
+          {heroImage ? (
+            <GatsbyImage image={heroImage} alt={post.frontmatter.title} />
+          ) : (
+            <div
+              className={`post-hero-placeholder ${styles.postHeroPlaceholder}`}
+            >
+              <span>
+                {post.frontmatter.tags?.[0] ||
+                  post.frontmatter.author?.id ||
+                  ""}
+              </span>
+            </div>
+          )}
         </Link>
       </div>
       <div className="post-card-title">
-        <Link to={post.fields.slug}>
-          {post.frontmatter.title}
-        </Link>
+        <Link to={post.fields.slug}>{post.frontmatter.title}</Link>
       </div>
-      {
-        post.frontmatter.tags?.length
-        ? <div className="post-card-tags">{<TagList tags={post.frontmatter.tags} />}</div>
-        : null
-      }
-      {
-        showDescription
-        ? <div className="post-card-description">{description}</div>
-        : null
-      }
-      <div className="post-card-footer">
-      <div className="post-card-date">
-          { post.frontmatter.date }
+      {post.frontmatter.tags?.length ? (
+        <div className="post-card-tags">
+          {<TagList tags={post.frontmatter.tags} />}
         </div>
+      ) : null}
+      {showDescription ? (
+        <div className="post-card-description">{description}</div>
+      ) : null}
+      <div className="post-card-footer">
+        <div className="post-card-date">{post.frontmatter.date}</div>
         <div className="post-card-author">
-          { avatarImage && post.frontmatter.author
-            ? <AuthorLink
-                name={post.frontmatter.author.name}
-                github={post.frontmatter.author.id}
-                avatarImage={avatarImage}
-                reverse={true}
-                />
-            : null}
+          {avatarImage && post.frontmatter.author ? (
+            <AuthorLink
+              name={post.frontmatter.author.name}
+              github={post.frontmatter.author.id}
+              avatarImage={avatarImage}
+              reverse={true}
+            />
+          ) : null}
         </div>
       </div>
     </div>
-  );
+  )
 }

--- a/src/components/post-toc/index.tsx
+++ b/src/components/post-toc/index.tsx
@@ -23,7 +23,9 @@ export default function PostToc(props: Props) {
       const elems = document.querySelectorAll('h2[id],h3[id],h4[id]')
       if (elems.length === 0) { return; }
       const activeIndex = Array.from(elems).findIndex(x => x.getBoundingClientRect().top - 150 > 0)
-      const activeElem = activeIndex > 0 ? elems[activeIndex - 1] : elems[0]
+      const activeElem = activeIndex === 0
+        ? elems[0]
+        : activeIndex > 0 ? elems[activeIndex - 1] : elems[elems.length - 1]
       setActiveAnchor(activeElem?.id || '')
     };
     document.addEventListener('scroll', onScroll, { passive: true })

--- a/src/components/post-toc/index.tsx
+++ b/src/components/post-toc/index.tsx
@@ -1,44 +1,52 @@
-import React, { useEffect, useState } from "react";
-import { AnchorLink } from "gatsby-plugin-anchor-links";
+import React, { useEffect, useState } from "react"
+import { AnchorLink } from "gatsby-plugin-anchor-links"
 import * as styles from "./index.module.css"
 
 type Heading = {
-  id: string,
-  value: string,
-  depth: number,
+  id: string
+  value: string
+  depth: number
 }
 
 type Props = {
-  headings: Heading[],
-  page?: string,
-  className?: string,
-};
+  headings: Heading[]
+  page?: string
+  className?: string
+}
 
 export default function PostToc(props: Props) {
-
-  const [activeAnchor, setActiveAnchor] = useState('');
+  const [activeAnchor, setActiveAnchor] = useState("")
 
   useEffect(() => {
     const onScroll = () => {
-      const elems = document.querySelectorAll('h2[id],h3[id],h4[id]')
-      if (elems.length === 0) { return; }
-      const activeIndex = Array.from(elems).findIndex(x => x.getBoundingClientRect().top - 150 > 0)
-      const activeElem = activeIndex === 0
-        ? elems[0]
-        : activeIndex > 0 ? elems[activeIndex - 1] : elems[elems.length - 1]
-      setActiveAnchor(activeElem?.id || '')
-    };
-    document.addEventListener('scroll', onScroll, { passive: true })
-    return () => {
-      document.removeEventListener('scroll', onScroll)
+      const elems = document.querySelectorAll("h2[id],h3[id],h4[id]")
+      if (elems.length === 0) {
+        return
+      }
+      const activeIndex = Array.from(elems).findIndex(
+        (x) => x.getBoundingClientRect().top - 150 > 0
+      )
+      const activeElem =
+        activeIndex === 0
+          ? elems[0]
+          : activeIndex > 0
+          ? elems[activeIndex - 1]
+          : elems[elems.length - 1]
+      setActiveAnchor(activeElem?.id || "")
     }
-  }, [activeAnchor]);
+    document.addEventListener("scroll", onScroll, { passive: true })
+    return () => {
+      document.removeEventListener("scroll", onScroll)
+    }
+  }, [activeAnchor])
 
   function createHeading(h: Heading) {
     return (
       <li
         key={`post-toc-item-${h.id}`}
-        className={`post-toc-item post-toc-item-depth-${h.depth - 1} ${styles[`depth${h.depth - 1}`]} ${h.id === activeAnchor ? 'post-toc-item-active' : ''}`}
+        className={`post-toc-item post-toc-item-depth-${h.depth - 1} ${
+          styles[`depth${h.depth - 1}`]
+        } ${h.id === activeAnchor ? "post-toc-item-active" : ""}`}
       >
         <AnchorLink to={`${props.page}#${h.id}`}>{h.value}</AnchorLink>
       </li>
@@ -47,10 +55,9 @@ export default function PostToc(props: Props) {
 
   return (
     <div className={`post-toc ${styles.container}`}>
-      <ul className={props.className || ''}>
-        {props.headings.map(x => createHeading(x))}
+      <ul className={props.className || ""}>
+        {props.headings.map((x) => createHeading(x))}
       </ul>
     </div>
-  );
-
+  )
 }

--- a/src/components/post-toc/index.tsx
+++ b/src/components/post-toc/index.tsx
@@ -1,5 +1,5 @@
+import React, { useEffect, useState } from "react";
 import { AnchorLink } from "gatsby-plugin-anchor-links";
-import React from "react";
 import * as styles from "./index.module.css"
 
 type Heading = {
@@ -16,11 +16,27 @@ type Props = {
 
 export default function PostToc(props: Props) {
 
+  const [activeAnchor, setActiveAnchor] = useState('');
+
+  useEffect(() => {
+    const onScroll = () => {
+      const elems = document.querySelectorAll('h2[id],h3[id],h4[id]')
+      if (elems.length === 0) { return; }
+      const activeIndex = Array.from(elems).findIndex(x => x.getBoundingClientRect().top - 150 > 0)
+      const activeElem = activeIndex > 0 ? elems[activeIndex - 1] : elems[0]
+      setActiveAnchor(activeElem?.id || '')
+    };
+    document.addEventListener('scroll', onScroll, { passive: true })
+    return () => {
+      document.removeEventListener('scroll', onScroll)
+    }
+  }, [activeAnchor]);
+
   function createHeading(h: Heading) {
     return (
       <li
         key={`post-toc-item-${h.id}`}
-        className={`post-toc-item post-toc-item-depth-${h.depth - 1} ${styles[`depth${h.depth - 1}`]}`}
+        className={`post-toc-item post-toc-item-depth-${h.depth - 1} ${styles[`depth${h.depth - 1}`]} ${h.id === activeAnchor ? 'post-toc-item-active' : ''}`}
       >
         <AnchorLink to={`${props.page}#${h.id}`}>{h.value}</AnchorLink>
       </li>

--- a/src/components/seo/index.tsx
+++ b/src/components/seo/index.tsx
@@ -3,14 +3,20 @@ import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
 type Props = {
-  description?: string;
-  lang?: string;
-  meta?: any[];
-  title?: string;
-  keywords?: string[];
+  description?: string
+  lang?: string
+  meta?: any[]
+  title?: string
+  keywords?: string[]
 }
 
-export default function Seo({ description, lang, meta, title, keywords }: Props) {
+export default function Seo({
+  description,
+  lang,
+  meta,
+  title,
+  keywords,
+}: Props) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -30,7 +36,7 @@ export default function Seo({ description, lang, meta, title, keywords }: Props)
   return (
     <Helmet
       htmlAttributes={{
-        lang: lang || 'ja',
+        lang: lang || "ja",
       }}
       title={title || defaultTitle}
       titleTemplate={title && defaultTitle ? `%s | ${defaultTitle}` : undefined}
@@ -41,8 +47,8 @@ export default function Seo({ description, lang, meta, title, keywords }: Props)
         },
         {
           name: `keywords`,
-          content: keywords?.join(','),
-          itemprop: 'keywords',
+          content: keywords?.join(","),
+          itemprop: "keywords",
         },
         {
           property: `og:title`,

--- a/src/components/tag-list/index.tsx
+++ b/src/components/tag-list/index.tsx
@@ -1,19 +1,18 @@
-import React from "react";
-import { Link } from "gatsby";
+import React from "react"
+import { Link } from "gatsby"
 
-import { tagNameToPageUrl } from "utils/tag";
+import { tagNameToPageUrl } from "utils/tag"
 
 import * as styles from "./index.module.css"
 
 export default function TagList(props: { tags: string[] }) {
-
   // make unique
   const tags = [...new Set(props.tags)]
 
   return (
     <div className={`tag-list ${styles.container}`}>
       <ul itemProp="keywords" className={`tag-highlight-first`} role="list">
-        {tags.map(tag => (
+        {tags.map((tag) => (
           <Link
             key={`tag-${tag}`}
             to={tagNameToPageUrl(tag)}
@@ -26,6 +25,5 @@ export default function TagList(props: { tags: string[] }) {
         ))}
       </ul>
     </div>
-  );
-  
+  )
 }

--- a/src/components/theme-switcher/index.tsx
+++ b/src/components/theme-switcher/index.tsx
@@ -9,15 +9,14 @@ export default function ThemeSwitcher(props: {
   bodyClassOnDark?: string
   bodyClassOnLight?: string
 }) {
-
   const { settingKey, tooltip } = props
 
-  const PrefersColorScheme = '(prefers-color-scheme: dark)'
-  const DarkSettingValue = 'dark'
-  const LigthSettingValue = 'light'
+  const PrefersColorScheme = "(prefers-color-scheme: dark)"
+  const DarkSettingValue = "dark"
+  const LigthSettingValue = "light"
 
-  const bodyClassOnDark = props.bodyClassOnDark || 'theme-dark'
-  const bodyClassOnLight = props.bodyClassOnLight || 'theme-light'
+  const bodyClassOnDark = props.bodyClassOnDark || "theme-dark"
+  const bodyClassOnLight = props.bodyClassOnLight || "theme-light"
 
   const [isDark, setIsDark] = useState(false)
 
@@ -36,14 +35,17 @@ export default function ThemeSwitcher(props: {
     }
   }, [isDark, settingKey])
 
-  const onChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
-    const val = e.currentTarget.checked ? DarkSettingValue : LigthSettingValue;
-    localStorage.setItem(settingKey, val)
-    setIsDark(e.currentTarget.checked)
-  }, [isDark, settingKey])
+  const onChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const val = e.currentTarget.checked ? DarkSettingValue : LigthSettingValue
+      localStorage.setItem(settingKey, val)
+      setIsDark(e.currentTarget.checked)
+    },
+    [isDark, settingKey]
+  )
 
-  const className = props.className || 'theme-switcher'
-  const checkboxId = props.checkboxId || 'theme-switcher'
+  const className = props.className || "theme-switcher"
+  const checkboxId = props.checkboxId || "theme-switcher"
 
   return (
     <div className={`${className} ${styles.themeSwitcher}`}>
@@ -52,9 +54,8 @@ export default function ThemeSwitcher(props: {
         type="checkbox"
         checked={isDark}
         onChange={onChange}
-        />
-      <label htmlFor={checkboxId} title={tooltip}/>
+      />
+      <label htmlFor={checkboxId} title={tooltip} />
     </div>
   )
-
 }

--- a/src/components/top-page-heading/index.tsx
+++ b/src/components/top-page-heading/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React from "react"
 
 type Props = {
   title: string
@@ -6,7 +6,7 @@ type Props = {
 }
 
 export default function TopPageHeading(props: Props) {
-  const { title, sub } = props;
+  const { title, sub } = props
 
   return (
     <h2 className={`top-page-heading`}>

--- a/src/components/top-page-hero/index.tsx
+++ b/src/components/top-page-hero/index.tsx
@@ -1,21 +1,22 @@
-import { StaticImage } from "gatsby-plugin-image";
-import React from "react";
+import { StaticImage } from "gatsby-plugin-image"
+import React from "react"
 
-type Props = {
-
-}
+type Props = {}
 
 export default function TopPageHero(props: Props) {
-
   return (
     <div className={`top-page-hero`}>
       <StaticImage
         src="../../images/top-page-hero.jpg"
         alt=""
-        transformOptions={{ fit: "contain", cropFocus: "attention"}}
-        />
-      <div className={`top-page-hero-copy top-page-hero-copy-1`}>Beyond our knowledge</div>
-      <div className={`top-page-hero-copy top-page-hero-copy-2`}>知識の向こう側へ</div>
+        transformOptions={{ fit: "contain", cropFocus: "attention" }}
+      />
+      <div className={`top-page-hero-copy top-page-hero-copy-1`}>
+        Beyond our knowledge
+      </div>
+      <div className={`top-page-hero-copy top-page-hero-copy-2`}>
+        知識の向こう側へ
+      </div>
     </div>
   )
 }

--- a/src/gatsby-node/index.ts
+++ b/src/gatsby-node/index.ts
@@ -4,11 +4,15 @@ import { GatsbyNode, Node } from "gatsby"
 import { createFilePath, createRemoteFileNode } from "gatsby-source-filesystem"
 import { tagNameToPageUrl } from "../utils/tag"
 
-const { paginate } = require('gatsby-awesome-pagination')
+const { paginate } = require("gatsby-awesome-pagination")
 
-export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions, reporter }) => {
+export const createPages: GatsbyNode["createPages"] = async ({
+  graphql,
+  actions,
+  reporter,
+}) => {
   const { createPage } = actions
-  
+
   type Post = {
     id: string
     fields: {
@@ -41,9 +45,7 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
             }
           }
         }
-        tagsGroup: allMarkdownRemark(
-          limit: 2000
-          ) {
+        tagsGroup: allMarkdownRemark(limit: 2000) {
           group(field: frontmatter___tags) {
             fieldValue
             totalCount
@@ -67,13 +69,17 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
   if (posts.length > 0) {
     function getDuplicateSlugs(posts: Post[]) {
       const counts = posts.reduce(
-        (p, c) => ({ ...p, [c.fields.slug]: (p[c.fields.slug] || 0) + 1 }), {} as { [slug: string]: number});
-      const duplicates = Object.keys(counts).filter(x => counts[x] > 1);
-      return duplicates.length > 0 ? duplicates : null;
+        (p, c) => ({ ...p, [c.fields.slug]: (p[c.fields.slug] || 0) + 1 }),
+        {} as { [slug: string]: number }
+      )
+      const duplicates = Object.keys(counts).filter((x) => counts[x] > 1)
+      return duplicates.length > 0 ? duplicates : null
     }
-    const duplicateSlugs = getDuplicateSlugs(posts);
+    const duplicateSlugs = getDuplicateSlugs(posts)
     if (duplicateSlugs) {
-      reporter.panicOnBuild(`Duplicate slugs detected ${JSON.stringify(duplicateSlugs)}`)
+      reporter.panicOnBuild(
+        `Duplicate slugs detected ${JSON.stringify(duplicateSlugs)}`
+      )
     }
     posts.forEach((post, index) => {
       createPage({
@@ -86,12 +92,12 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
     })
 
     const postListTemplate = path.resolve(`./src/templates/post-list.tsx`)
-  
+
     paginate({
       createPage,
       items: posts,
       itemsPerPage: 30,
-      pathPrefix: '/posts',
+      pathPrefix: "/posts",
       component: postListTemplate,
     })
 
@@ -124,24 +130,32 @@ export const createPages: GatsbyNode["createPages"] = async ({ graphql, actions,
 }
 
 function getMatchedHeroImagePath(fileAbsolutePath: string, slug: string) {
-  const candidateExtensions = ['jpg', 'jpeg', 'png']
+  const candidateExtensions = ["jpg", "jpeg", "png"]
   // like `slug.jpg`
   for (const ext of candidateExtensions) {
-    const testPath = path.resolve(fileAbsolutePath, '..', 'images', `${slug}\.${ext}`)
+    const testPath = path.resolve(
+      fileAbsolutePath,
+      "..",
+      "images",
+      `${slug}\.${ext}`
+    )
     try {
       fs.statSync(testPath)
-      return path.relative(path.resolve(fileAbsolutePath, '..'), testPath)
-    }
-    catch {}
+      return path.relative(path.resolve(fileAbsolutePath, ".."), testPath)
+    } catch {}
   }
   // fallback to like `slug-1.jpg`
   for (const ext of candidateExtensions) {
-    const testPath = path.resolve(fileAbsolutePath, '..', 'images', `${slug}-1\.${ext}`)
+    const testPath = path.resolve(
+      fileAbsolutePath,
+      "..",
+      "images",
+      `${slug}-1\.${ext}`
+    )
     try {
       fs.statSync(testPath)
-      return path.relative(path.resolve(fileAbsolutePath, '..'), testPath)
-    }
-    catch {}
+      return path.relative(path.resolve(fileAbsolutePath, ".."), testPath)
+    } catch {}
   }
   return null
 }
@@ -164,14 +178,12 @@ export const onCreateNode: GatsbyNode["onCreateNode"] = async ({
       author: string
       avatarImage__NODE: any
     }
-  };
+  }
   if (node.internal.type === `MarkdownRemark`) {
     const slug = createFilePath({ node, getNode })
 
     // Flatten slug (e.g. /kenzauros/2021/hogehoge/ => /hogehoge/)
-    const value = slug.match(/([^/]+)\/$/)
-      ? `/${RegExp.$1}/`
-      : slug;
+    const value = slug.match(/([^/]+)\/$/) ? `/${RegExp.$1}/` : slug
 
     createNodeField({
       name: `slug`,
@@ -180,8 +192,11 @@ export const onCreateNode: GatsbyNode["onCreateNode"] = async ({
     })
 
     // Hero image (eye catch image)
-    const filename = slug.match(/([^/]+)\/$/) ? RegExp.$1 : '';
-    const heroImagePath = getMatchedHeroImagePath(mdr.fileAbsolutePath, filename)
+    const filename = slug.match(/([^/]+)\/$/) ? RegExp.$1 : ""
+    const heroImagePath = getMatchedHeroImagePath(
+      mdr.fileAbsolutePath,
+      filename
+    )
     createNodeField({
       name: `heroImage`,
       node,
@@ -190,7 +205,7 @@ export const onCreateNode: GatsbyNode["onCreateNode"] = async ({
 
     // Author avatar from exteranal source
     if (mdr.frontmatter.author) {
-      const url = `https://avatars.githubusercontent.com/${mdr.frontmatter.author}`;
+      const url = `https://avatars.githubusercontent.com/${mdr.frontmatter.author}`
       // https://www.gatsbyjs.com/docs/how-to/images-and-media/preprocessing-external-images/
       const fileNode = await createRemoteFileNode({
         url, // string that points to the URL of the image
@@ -208,10 +223,11 @@ export const onCreateNode: GatsbyNode["onCreateNode"] = async ({
   }
 }
 
-export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] = ({ actions }) => {
-  const { createTypes } = actions
+export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] =
+  ({ actions }) => {
+    const { createTypes } = actions
 
-  createTypes(`
+    createTypes(`
     type AuthorYaml implements Node {
       id: String
       name: String
@@ -235,4 +251,4 @@ export const createSchemaCustomization: GatsbyNode["createSchemaCustomization"] 
       heroImage: File @fileByRelativePath
     }
   `)
-}
+  }

--- a/src/module.css.d.ts
+++ b/src/module.css.d.ts
@@ -1,7 +1,7 @@
-declare module '*.module.css' {
+declare module "*.module.css" {
   interface IClassNames {
     [className: string]: string
   }
-  const classNames: IClassNames;
-  export = classNames;
+  const classNames: IClassNames
+  export = classNames
 }

--- a/src/pages/404.tsx
+++ b/src/pages/404.tsx
@@ -20,7 +20,7 @@ type Props = {
 
 const NotFoundPage = ({ data, location }: Props) => {
   const siteTitle = data.site.siteMetadata.title
-  const { pathname } = location;
+  const { pathname } = location
 
   return (
     <>
@@ -40,7 +40,9 @@ const NotFoundPage = ({ data, location }: Props) => {
           <div className="error-page-info">
             <h1>404</h1>
             <div className="error-page-message">Page not found</div>
-            <Link to='/' className="error-page-link-button button">Go to Home page</Link>
+            <Link to="/" className="error-page-link-button button">
+              Go to Home page
+            </Link>
           </div>
         </div>
       </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,22 +1,22 @@
 import * as React from "react"
 import { graphql } from "gatsby"
-import { Helmet } from "react-helmet";
+import { Helmet } from "react-helmet"
 
-import Layout from "components/layout";
-import Seo from "components/seo";
-import PostCard, { PostSummary } from "components/post-card";
-import TopPageHeading from "components/top-page-heading";
-import TopPageHero from "components/top-page-hero";
-import MoreLink from "components/more-link";
-import { tagNameToPageUrl } from "utils/tag";
+import Layout from "components/layout"
+import Seo from "components/seo"
+import PostCard, { PostSummary } from "components/post-card"
+import TopPageHeading from "components/top-page-heading"
+import TopPageHero from "components/top-page-hero"
+import MoreLink from "components/more-link"
+import { tagNameToPageUrl } from "utils/tag"
 
 const featuredTags = [
-  { name: 'AWS', sub: 'Amazon Web Services' },
-  { name: 'Web', sub: 'Web realted technologies' },
-  { name: '仮想化技術', sub: 'Virtualization' },
-  { name: 'Linux', sub: 'Amazon Linux, CentOS, Ubuntu...' },
-  { name: '.NET', sub: '.NET, .NET Framework, C#, VB.NET...' },
-  { name: 'Windows', sub: 'Windows Server, Windows 10' },
+  { name: "AWS", sub: "Amazon Web Services" },
+  { name: "Web", sub: "Web realted technologies" },
+  { name: "仮想化技術", sub: "Virtualization" },
+  { name: "Linux", sub: "Amazon Linux, CentOS, Ubuntu..." },
+  { name: ".NET", sub: ".NET, .NET Framework, C#, VB.NET..." },
+  { name: "Windows", sub: "Windows Server, Windows 10" },
 ]
 
 type DataType = {
@@ -35,43 +35,51 @@ type DataType = {
 type Props = {
   data: DataType
   location: { pathname: string }
-};
+}
 
 export default function BlogIndex({ data, location }: Props) {
   const siteTitle = data.site.siteMetadata?.title || `Title`
 
-  const latestPostIdList = data.latestPosts.nodes?.map(x => x.id)
+  const latestPostIdList = data.latestPosts.nodes?.map((x) => x.id)
 
-  const latestPosts = data.latestPosts.nodes
-    ? (
-      <div className="global-root-group">
-        <div className="global-wrapper">
-          <TopPageHeading title="最新記事" sub="Latest articles" />
-          <div className={`featured-post-card-list`}>
-            {data.latestPosts.nodes.map((post: PostSummary, n: number) =>
-              <PostCard key={`post-card-${post.id}`} post={post} showDescription={n === 0} />)}
-          </div>
-          <MoreLink to='/posts/' />
+  const latestPosts = data.latestPosts.nodes ? (
+    <div className="global-root-group">
+      <div className="global-wrapper">
+        <TopPageHeading title="最新記事" sub="Latest articles" />
+        <div className={`featured-post-card-list`}>
+          {data.latestPosts.nodes.map((post: PostSummary, n: number) => (
+            <PostCard
+              key={`post-card-${post.id}`}
+              post={post}
+              showDescription={n === 0}
+            />
+          ))}
         </div>
+        <MoreLink to="/posts/" />
       </div>
-    )
-    : null
+    </div>
+  ) : null
 
   const featuredTagPostLists = featuredTags.map((tag, i) => {
-    const posts = data[`topics${i + 1}`].nodes?.filter(x => !latestPostIdList?.includes(x.id)).slice(0, 5)
-    if (!posts) { return null }
+    const posts = data[`topics${i + 1}`].nodes
+      ?.filter((x) => !latestPostIdList?.includes(x.id))
+      .slice(0, 5)
+    if (!posts) {
+      return null
+    }
     const url = tagNameToPageUrl(tag.name)
     return (
       <div key={`featured-post-${i}`} className="global-root-group">
         <div className="global-wrapper">
           <TopPageHeading title={tag.name} sub={tag.sub} />
           <div className={`featured-post-card-list`}>
-            {posts?.map((post: PostSummary, n: number) =>
+            {posts?.map((post: PostSummary, n: number) => (
               <PostCard
                 key={`post-${post.id}`}
                 post={post}
                 showDescription={n === 0}
-              />) || null}
+              />
+            )) || null}
           </div>
           <MoreLink to={url} />
         </div>
@@ -83,8 +91,15 @@ export default function BlogIndex({ data, location }: Props) {
     <Layout location={location} title={siteTitle}>
       <Helmet>
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="crossOrigin" />
-        <link href="https://fonts.googleapis.com/css2?family=Josefin+Sans&display=swap" rel="stylesheet" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="crossOrigin"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Josefin+Sans&display=swap"
+          rel="stylesheet"
+        />
       </Helmet>
       <Seo />
       <TopPageHero />
@@ -94,7 +109,6 @@ export default function BlogIndex({ data, location }: Props) {
   )
 }
 
-
 export const pageQuery = graphql`
   query {
     site {
@@ -102,63 +116,63 @@ export const pageQuery = graphql`
         title
       }
     }
-    latestPosts: allMarkdownRemark (
-      sort: {fields: frontmatter___date, order: DESC}
+    latestPosts: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
       limit: 5
     ) {
       nodes {
         ...PostSummary
       }
     }
-    topics1: allMarkdownRemark (
-      sort: {fields: frontmatter___date, order: DESC}
+    topics1: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
       limit: 10
-      filter: {frontmatter: {tags: {eq: "AWS"}}}
+      filter: { frontmatter: { tags: { eq: "AWS" } } }
     ) {
       nodes {
         ...PostSummary
       }
     }
-    topics2: allMarkdownRemark (
-      sort: {fields: frontmatter___date, order: DESC}
+    topics2: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
       limit: 10
-      filter: {frontmatter: {tags: {eq: "Web"}}}
+      filter: { frontmatter: { tags: { eq: "Web" } } }
     ) {
       nodes {
         ...PostSummary
       }
     }
-    topics3: allMarkdownRemark (
-      sort: {fields: frontmatter___date, order: DESC}
+    topics3: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
       limit: 10
-      filter: {frontmatter: {tags: {eq: "仮想化技術"}}}
+      filter: { frontmatter: { tags: { eq: "仮想化技術" } } }
     ) {
       nodes {
         ...PostSummary
       }
     }
-    topics4: allMarkdownRemark (
-      sort: {fields: frontmatter___date, order: DESC}
+    topics4: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
       limit: 10
-      filter: {frontmatter: {tags: {eq: "Linux"}}}
+      filter: { frontmatter: { tags: { eq: "Linux" } } }
     ) {
       nodes {
         ...PostSummary
       }
     }
-    topics5: allMarkdownRemark (
-      sort: {fields: frontmatter___date, order: DESC}
+    topics5: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
       limit: 10
-      filter: {frontmatter: {tags: {eq: ".NET"}}}
+      filter: { frontmatter: { tags: { eq: ".NET" } } }
     ) {
       nodes {
         ...PostSummary
       }
     }
-    topics6: allMarkdownRemark (
-      sort: {fields: frontmatter___date, order: DESC}
+    topics6: allMarkdownRemark(
+      sort: { fields: frontmatter___date, order: DESC }
       limit: 10
-      filter: {frontmatter: {tags: {eq: "Windows"}}}
+      filter: { frontmatter: { tags: { eq: "Windows" } } }
     ) {
       nodes {
         ...PostSummary

--- a/src/pages/tags.tsx
+++ b/src/pages/tags.tsx
@@ -18,7 +18,7 @@ type DataType = {
       totalCount: number
     }[]
   }
-};
+}
 
 type Props = {
   data: DataType
@@ -36,11 +36,13 @@ export default function TagsPage(props: Props) {
       allMarkdownRemark: { group },
     },
     location,
-  } = props;
+  } = props
 
-  const tags = group.map(({ fieldValue: tagName, totalCount }) =>
-    ({ tagName, totalCount }))
-  
+  const tags = group.map(({ fieldValue: tagName, totalCount }) => ({
+    tagName,
+    totalCount,
+  }))
+
   const grouped = tags.reduce((p, c) => {
     const firstChar = c.tagName.substring(0, 1)
     if (!p[firstChar]) {
@@ -50,7 +52,7 @@ export default function TagsPage(props: Props) {
     return p
   }, {} as { [firstChar: string]: TagObject[] })
 
-  const tagmap = (Object.keys(grouped).map(firstChar => {
+  const tagmap = Object.keys(grouped).map((firstChar) => {
     const tags = grouped[firstChar]
     tags.sort((a, b) => b.totalCount - a.totalCount)
     return (
@@ -72,26 +74,21 @@ export default function TagsPage(props: Props) {
         </div>
       </div>
     )
-  }))
+  })
 
   const breadcrumb: BreadcrumbListItem[] = [
-    { name: 'ホーム', current: false, url: '/' },
-    { name: 'タグ一覧', current: true, url: '/tags/' },
+    { name: "ホーム", current: false, url: "/" },
+    { name: "タグ一覧", current: true, url: "/tags/" },
   ]
 
   const title = `タグ一覧`
   const description = `${title} のタグ一覧です`
   return (
     <Layout location={location} title={title}>
-      <Seo
-        title={title}
-        description={description}
-      />
+      <Seo title={title} description={description} />
       <div className="full-wide-container">
         <BreadcrumbList items={breadcrumb} />
-        <main>
-          {tagmap}
-        </main>
+        <main>{tagmap}</main>
       </div>
     </Layout>
   )

--- a/src/styles/common-elements.css
+++ b/src/styles/common-elements.css
@@ -39,8 +39,8 @@ a:focus {
 
 a.button {
   padding: var(--spacing-2) var(--spacing-4);
-  background-color: var(--color-bright);
-  color: var(--color-text-invert);
+  background-color: var(--color-button-bg);
+  color: var(--color-button-text);
   text-decoration: none;
   text-align: center;
   margin-top: var(--spacing-0);

--- a/src/styles/common-elements.css
+++ b/src/styles/common-elements.css
@@ -75,7 +75,7 @@ body.theme-dark .site-logo-dark {
   width: var(--scrollbar-size);
   height: var(--scrollbar-size);
 }
- 
+
 ::-webkit-scrollbar-thumb {
   background: var(--color-scrollbar-thumb);
   border-radius: calc(var(--scrollbar-size) / 2);

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -184,6 +184,10 @@
   border-bottom: 3px double var(--color-table-border);
 }
 
+.post table thead tr th:not([align]) {
+  text-align: left;
+}
+
 .post strong {
   background: linear-gradient(transparent 60%, var(--color-line-marker-1) 60%);
   padding: 0.1em;

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -167,14 +167,21 @@
 }
 
 .post table {
-  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
   margin-bottom: var(--spacing-8);
   border-collapse: collapse;
   border-spacing: 0.25rem;
 }
 
+.post table th,
+.post table td {
+  padding: var(--spacing-1) var(--spacing-2);
+  border-bottom: 1px solid var(--color-table-border);
+}
+
 .post table thead tr th {
-  border-bottom: 1px solid var(--color-accent);
+  border-bottom: 3px double var(--color-table-border);
 }
 
 .post strong {
@@ -270,6 +277,11 @@
 
 .post-hero {
   margin-bottom: var(--spacing-5);
+}
+
+.post-bio {
+  line-height: var(--lineHeight-normal);
+  letter-spacing: var(--letterSpacing-relaxed);
 }
 
 .gatsby-highlight-code-line {

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -89,11 +89,11 @@
 /* Prose */
 
 .post p {
-  line-height: var(--lineHeight-relaxed);
   --baseline-multiplier: 0.179;
   --x-height-multiplier: 0.35;
   margin: var(--spacing-0) var(--spacing-0) var(--spacing-6) var(--spacing-0);
   padding: var(--spacing-0);
+  line-height: var(--lineHeight-relaxed);
   letter-spacing: var(--letterSpacing-relaxed);
 }
 
@@ -104,6 +104,7 @@
   margin-bottom: var(--spacing-8);
   list-style-position: outside;
   list-style-image: none;
+  letter-spacing: var(--letterSpacing-relaxed);
 }
 
 .post ul li,
@@ -125,13 +126,24 @@
 
 .post blockquote {
   color: var(--color-text-light);
-  margin-left: calc(-1 * var(--spacing-6));
-  margin-right: var(--spacing-8);
-  padding: var(--spacing-0) var(--spacing-0) var(--spacing-0) var(--spacing-6);
-  border-left: var(--spacing-1) solid var(--color-primary);
-  font-size: var(--fontSize-2);
-  font-style: italic;
+  margin-left: var(--spacing-6);
+  margin-right: var(--spacing-6);
+  padding: var(--spacing-8) var(--spacing-4) var(--spacing-2) var(--spacing-4);
   margin-bottom: var(--spacing-8);
+  position: relative;
+  background-color: var(--color-blockquote-bg);
+  border-radius: var(--corner-radius);
+}
+
+.post blockquote::before {
+  content: '“';
+  font-family: Consolas, Candara, Georgia, Serif;
+  font-weight: bold;
+  position: absolute;
+  top: 4px;
+  left: var(--spacing-2);
+  font-size: 48px;
+  line-height: 1;
 }
 
 .post blockquote > :last-child {
@@ -141,6 +153,17 @@
 .post blockquote > ul,
 .post blockquote > ol {
   list-style-position: inside;
+}
+
+.post blockquote > p {
+  margin-left: var(--spacing-6);
+  line-height: var(--lineHeight-normal);
+}
+
+.post blockquote cite {
+  display: block;
+  text-align: right;
+  font-style: normal;
 }
 
 .post table {

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -178,6 +178,7 @@
 .post table td {
   padding: var(--spacing-1) var(--spacing-2);
   border-bottom: 1px solid var(--color-table-border);
+  word-break: break-all;
 }
 
 .post table thead tr th {

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -37,6 +37,8 @@
 
 .post h2 {
   font-size: var(--fontSize-5);
+  padding: var(--spacing-2);
+  border-bottom: solid 1px var(--color-accent);
 }
 
 .post h3 {
@@ -78,7 +80,7 @@
   margin: var(--spacing-0) var(--spacing-0) var(--spacing-6) var(--spacing-0);
   padding: var(--spacing-0);
 }
- 
+
 .post ul,
 .post ol {
   margin-right: var(--spacing-0);
@@ -152,7 +154,7 @@
 
 .main-container > main {
   background-color: var(--color-bg);
-  padding: var(--spacing-4);
+  padding: var(--spacing-4) var(--spacing-6);
   grid-column: 1 / 2;
   grid-row: 2 / 3;
 }
@@ -233,13 +235,14 @@
 
 .gatsby-highlight {
   background-color: #272822;
+  border: solid 1px rgba(255, 255, 255, 0.2);
   border-radius: 0.25em;
   margin: 1em 0;
-  padding: 0.5em 1em;
+  padding: 0 1em;
 }
 
 .gatsby-highlight pre[class*="language-"] {
-  padding: 0;
+  padding: 0.5em 0;
 }
 
 .gatsby-highlight pre[class*="language-"].line-numbers {
@@ -266,6 +269,9 @@
 
 :not(pre) > code[class*="language-"] {
   padding: .1em .25em;
+  color: inherit;
+  background-color: var(--color-inline-code-bg);
+  text-shadow: none;
 }
 
 
@@ -279,11 +285,12 @@
   font-size: var(--fontSize-toc);
   background-color: var(--color-bg);
   margin: 0;
-  padding: var(--spacing-2) var(--spacing-3);
+  padding: var(--spacing-4);
 }
 
 .post-toc::before {
   content: 'もくじ';
+  font-size: var(--fontSize-1);
   display: block;
   height: 2em;
   top: -2em;
@@ -291,6 +298,7 @@
 
 .post-toc a {
   text-decoration: none;
+  color: var(--color-text-light);
 }
 
 .post-toc a:hover {
@@ -300,26 +308,83 @@
 .post-toc ul {
   margin: 0;
   padding: 0;
+  position: relative;
 }
 
-.post-toc li {
-  line-height: var(--lineHeight-normal);
-  list-style: none;
+.post-toc ul::before {
+  position: absolute;
+  content: "";
+  width: 2px;
+  background: var(--color-accent);
+  top: 15px;
+  bottom: 8px;
+  left: 5px;
+  border-radius: 0 0 5px 5px;
+  opacity: 0.5;
+}
+
+.post-toc li.post-toc-item {
+  position: relative;
+  line-height: var(--lineHeight-tight);
   margin: 0;
+  margin-top: var(--spacing-2);
 }
 
-.post-toc .post-toc-item-depth-1 {
-  padding-left: 0;
+.post-toc li.post-toc-item::before {
+  content: "";
+  position: absolute;
+  border-radius: 50%;
+  left: 0;
+  top: 3px;
+  width: 12px;
+  height: 12px;
+  background: var(--color-accent);
+  border: 2px solid var(--color-bg);
+  transition: background 0.5s ease;
 }
 
-.post-toc .post-toc-item-depth-2 {
-  padding-left: var(--spacing-4);
+.post-toc li.post-toc-item.post-toc-item-active a {
+  color: var(--color-text);
+  font-weight: var(--fontWeight-bold);
 }
 
-.post-toc .post-toc-item-depth-3 {
-  padding-left: var(--spacing-8);
+.post-toc li.post-toc-item.post-toc-item-active::before {
+  background: var(--color-primary);
 }
 
-.post-toc .post-toc-item-depth-4 {
-  padding-left: var(--spacing-12);
+.post-toc li.post-toc-item.post-toc-item-depth-1 {
+  padding-left: var(--spacing-6);
+}
+
+.post-toc li.post-toc-item.post-toc-item-depth-2 {
+  font-size: 0.95em;
+  padding-left: calc(var(--spacing-6) + var(--spacing-1));
+}
+
+.post-toc li.post-toc-item.post-toc-item-depth-2::before {
+  left: 1px;
+  width: 10px;
+  height: 10px;
+}
+
+.post-toc li.post-toc-item.post-toc-item-depth-3 {
+  font-size: 0.95em;
+  padding-left: calc(var(--spacing-6) + var(--spacing-1) * 2);
+}
+
+.post-toc li.post-toc-item.post-toc-item-depth-3::before {
+  left: 2px;
+  width: 8px;
+  height: 8px;
+}
+
+.post-toc li.post-toc-item.post-toc-item-depth-4 {
+  font-size: 1em;
+  padding-left: calc(var(--spacing-6) + var(--spacing-1) * 3);
+}
+
+.post-toc li.post-toc-item.post-toc-item-depth-4::before {
+  left: 3px;
+  width: 6px;
+  height: 6px;
 }

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -8,7 +8,7 @@
   margin-bottom: var(--spacing-1);
   font-family: var(--font-heading);
   line-height: var(--lineHeight-tight);
-  letter-spacing: -0.025em;
+  letter-spacing: var(--letterSpacing-normal);
 }
 
 .post h2,
@@ -36,13 +36,28 @@
 }
 
 .post h2 {
+  position: relative;
   font-size: var(--fontSize-5);
-  padding: var(--spacing-2);
-  border-bottom: solid 1px var(--color-accent);
+  padding: var(--spacing-1) var(--spacing-1);
+  padding-left: var(--spacing-5);
+}
+
+.post h2::before {
+  content: '';
+  display: block;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 8px;
+  height: 100%;
+  border-radius: 4px;
+  background-color: var(--color-secondary);
 }
 
 .post h3 {
   font-size: var(--fontSize-4);
+  padding: var(--spacing-2) var(--spacing-1);
+  border-bottom: solid 1px var(--color-accent);
 }
 
 .post h4 {
@@ -79,6 +94,7 @@
   --x-height-multiplier: 0.35;
   margin: var(--spacing-0) var(--spacing-0) var(--spacing-6) var(--spacing-0);
   padding: var(--spacing-0);
+  letter-spacing: var(--letterSpacing-relaxed);
 }
 
 .post ul,
@@ -92,6 +108,7 @@
 
 .post ul li,
 .post ol li {
+  line-height: var(--lineHeight-tight);
   padding-left: var(--spacing-0);
   margin-bottom: var(--spacing-2);
 }
@@ -100,13 +117,10 @@
   margin-bottom: calc(var(--spacing-8) / 2);
 }
 
-.post li *:last-child {
-  margin-bottom: var(--spacing-0);
-}
-
 .post li > ul {
   margin-left: var(--spacing-8);
-  margin-top: calc(var(--spacing-8) / 2);
+  margin-top: var(--spacing-2);
+  margin-bottom: var(--spacing-2);
 }
 
 .post blockquote {
@@ -138,6 +152,17 @@
 
 .post table thead tr th {
   border-bottom: 1px solid var(--color-accent);
+}
+
+.post strong {
+  background: linear-gradient(transparent 60%, var(--color-line-marker-1) 60%);
+  padding: 0.1em;
+}
+
+.post em {
+  font-style: normal;
+  background: linear-gradient(transparent 60%, var(--color-line-marker-2) 60%);
+  padding: 0.1em;
 }
 
 .main-container {
@@ -318,7 +343,7 @@
   background: var(--color-accent);
   top: 15px;
   bottom: 8px;
-  left: 5px;
+  left: 6px;
   border-radius: 0 0 5px 5px;
   opacity: 0.5;
 }
@@ -335,9 +360,9 @@
   position: absolute;
   border-radius: 50%;
   left: 0;
-  top: 3px;
-  width: 12px;
-  height: 12px;
+  top: 2px;
+  width: 14px;
+  height: 14px;
   background: var(--color-accent);
   border: 2px solid var(--color-bg);
   transition: background 0.5s ease;
@@ -358,29 +383,29 @@
 
 .post-toc li.post-toc-item.post-toc-item-depth-2 {
   font-size: 0.95em;
-  padding-left: calc(var(--spacing-6) + var(--spacing-1));
+  padding-left: calc(var(--spacing-6) + var(--spacing-2));
 }
 
 .post-toc li.post-toc-item.post-toc-item-depth-2::before {
-  left: 1px;
+  left: 2px;
   width: 10px;
   height: 10px;
 }
 
 .post-toc li.post-toc-item.post-toc-item-depth-3 {
   font-size: 0.95em;
-  padding-left: calc(var(--spacing-6) + var(--spacing-1) * 2);
+  padding-left: calc(var(--spacing-6) + var(--spacing-2) * 2);
 }
 
 .post-toc li.post-toc-item.post-toc-item-depth-3::before {
-  left: 2px;
+  left: 3px;
   width: 8px;
   height: 8px;
 }
 
 .post-toc li.post-toc-item.post-toc-item-depth-4 {
   font-size: 1em;
-  padding-left: calc(var(--spacing-6) + var(--spacing-1) * 3);
+  padding-left: calc(var(--spacing-6) + var(--spacing-2) * 3);
 }
 
 .post-toc li.post-toc-item.post-toc-item-depth-4::before {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -72,7 +72,7 @@
   --lineHeight-none: 1;
   --lineHeight-tight: 1.2;
   --lineHeight-normal: 1.5;
-  --lineHeight-relaxed: 1.625;
+  --lineHeight-relaxed: 1.9;
 
   --fontSize-0: 0.850rem;
   --fontSize-1: 1.000rem;
@@ -82,7 +82,7 @@
   --fontSize-5: 1.600rem;
   --fontSize-6: 1.800rem;
   --fontSize-7: 2.500rem;
-  --fontSize-toc: 0.9rem;
+  --fontSize-toc: 0.92rem;
   --fontSize-tag: 0.85rem;
   --fontSize-breadcrumb: 0.8rem;
 
@@ -101,13 +101,14 @@
   --color-tag-bg: #f1f1f1;
   --color-paginator-link-bg: darkgray;
   --color-paginator-link-bg-current: steelblue;
-  --color-jump-button-bg: #6197c4;
+  --color-jump-button-bg: var(--color-primary);
   --color-hero-placeholder-bg: linear-gradient(135deg, rgba(9,121,83,1) 0%, rgba(0,145,175,1) 100%);
   --color-hero-placeholder-bg2: linear-gradient(135deg, rgba(171,78,34,1) 0%, rgba(112,45,173,1) 100%);
   --color-hero-placeholder-text: white;
   --color-top-page-hero-bg: black;
   --color-top-page-hero-copy: white;
   --color-post-card-description-bg: #e6f3ff;
+  --color-inline-code-bg: #215aa012;
   
   --corner-radius: 0.25em;
 
@@ -126,7 +127,7 @@
 body.theme-dark {
   --color-bg-body: black;
   --color-bg: #202020;
-  --color-primary: #1577e7;
+  --color-primary: #4d9bf3;
   --color-bright: #2857FF;
   --color-text: #d1d1d1;
   --color-text-light: #b3bfd3;
@@ -139,11 +140,12 @@ body.theme-dark {
   --color-tag-bg: #444;
   --color-paginator-link-bg: darkgray;
   --color-paginator-link-bg-current: steelblue;
-  --color-jump-button-bg: steelblue;
+  --color-jump-button-bg: var(--color-primary);
   --color-hero-placeholder-text: white;
   --color-top-page-hero-bg: black;
   --color-top-page-hero-copy: white;
   --color-post-card-description-bg: #2e384d;
+  --color-inline-code-bg: #ffffff33;
 
   --box-shadow: 0em 0em 0.5em rgba(255, 255, 255, 0.2);
   --color-scrollbar-thumb: #727b88;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -115,6 +115,7 @@
   --color-inline-code-bg: #215aa012;
   --color-line-marker-1: #eecc0033;
   --color-line-marker-2: #00cc0033;
+  --color-blockquote-bg: #0000000c;
   
   --corner-radius: 0.25em;
 
@@ -155,6 +156,7 @@ body.theme-dark {
   --color-inline-code-bg: #ffffff33;
   --color-line-marker-1: #eecc0033;
   --color-line-marker-2: #00cc0033;
+  --color-blockquote-bg: #ffffff1c;
 
   --box-shadow: 0em 0em 0.5em rgba(255, 255, 255, 0.2);
   --color-scrollbar-thumb: #727b88;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -116,6 +116,7 @@
   --color-line-marker-1: #eecc0033;
   --color-line-marker-2: #00cc0033;
   --color-blockquote-bg: #0000000c;
+  --color-table-border: #00000033;
   
   --corner-radius: 0.25em;
 
@@ -157,6 +158,7 @@ body.theme-dark {
   --color-line-marker-1: #eecc0033;
   --color-line-marker-2: #00cc0033;
   --color-blockquote-bg: #ffffff1c;
+  --color-table-border: #ffffff44;
 
   --box-shadow: 0em 0em 0.5em rgba(255, 255, 255, 0.2);
   --color-scrollbar-thumb: #727b88;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -92,7 +92,6 @@
   --color-bg-body: #efefef;
   --color-bg: white;
   --color-primary: #0b58af;
-  --color-bright: #2857FF;
   --color-secondary: #09A1A3;
   --color-text: #2e353f;
   --color-text-light: #4f5969;
@@ -117,6 +116,8 @@
   --color-line-marker-2: #00cc0033;
   --color-blockquote-bg: #0000000c;
   --color-table-border: #00000033;
+  --color-button-text: #eee;
+  --color-button-bg: #2857FF;
   
   --corner-radius: 0.25em;
 
@@ -136,7 +137,6 @@ body.theme-dark {
   --color-bg-body: black;
   --color-bg: #202020;
   --color-primary: #4d9bf3;
-  --color-bright: #5779f5;
   --color-secondary: #09A1A3;
   --color-text: #d1d1d1;
   --color-text-light: #b3bfd3;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -136,7 +136,7 @@ body.theme-dark {
   --color-bg-body: black;
   --color-bg: #202020;
   --color-primary: #4d9bf3;
-  --color-bright: #2857FF;
+  --color-bright: #5779f5;
   --color-secondary: #09A1A3;
   --color-text: #d1d1d1;
   --color-text-light: #b3bfd3;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -74,13 +74,16 @@
   --lineHeight-normal: 1.5;
   --lineHeight-relaxed: 1.9;
 
+  --letterSpacing-normal: normal;
+  --letterSpacing-relaxed: 0.05em;
+
   --fontSize-0: 0.850rem;
   --fontSize-1: 1.000rem;
   --fontSize-2: 1.200rem;
   --fontSize-3: 1.300rem;
-  --fontSize-4: 1.400rem;
-  --fontSize-5: 1.600rem;
-  --fontSize-6: 1.800rem;
+  --fontSize-4: 1.500rem;
+  --fontSize-5: 1.700rem;
+  --fontSize-6: 2.000rem;
   --fontSize-7: 2.500rem;
   --fontSize-toc: 0.92rem;
   --fontSize-tag: 0.85rem;
@@ -90,6 +93,7 @@
   --color-bg: white;
   --color-primary: #0b58af;
   --color-bright: #2857FF;
+  --color-secondary: #09A1A3;
   --color-text: #2e353f;
   --color-text-light: #4f5969;
   --color-text-light-light: #8e99aa;
@@ -109,6 +113,8 @@
   --color-top-page-hero-copy: white;
   --color-post-card-description-bg: #e6f3ff;
   --color-inline-code-bg: #215aa012;
+  --color-line-marker-1: #eecc0033;
+  --color-line-marker-2: #00cc0033;
   
   --corner-radius: 0.25em;
 
@@ -129,6 +135,7 @@ body.theme-dark {
   --color-bg: #202020;
   --color-primary: #4d9bf3;
   --color-bright: #2857FF;
+  --color-secondary: #09A1A3;
   --color-text: #d1d1d1;
   --color-text-light: #b3bfd3;
   --color-text-light-light: #9fabbe;
@@ -146,6 +153,8 @@ body.theme-dark {
   --color-top-page-hero-copy: white;
   --color-post-card-description-bg: #2e384d;
   --color-inline-code-bg: #ffffff33;
+  --color-line-marker-1: #eecc0033;
+  --color-line-marker-2: #00cc0033;
 
   --box-shadow: 0em 0em 0.5em rgba(255, 255, 255, 0.2);
   --color-scrollbar-thumb: #727b88;

--- a/src/templates/post-list.tsx
+++ b/src/templates/post-list.tsx
@@ -5,7 +5,7 @@ import { PageContext } from "types/pagination"
 import Layout from "components/layout"
 import Seo from "components/seo"
 import Paginator from "components/paginator"
-import BreadcrumbList, { BreadcrumbListItem } from "components/breadcrumb-list";
+import BreadcrumbList, { BreadcrumbListItem } from "components/breadcrumb-list"
 import PostCardList from "components/post-card-list"
 import { PostSummary } from "components/post-card"
 
@@ -19,21 +19,25 @@ type DataType = {
   allMarkdownRemark: {
     nodes: PostSummary[]
   }
-};
+}
 
 type Props = {
   data: DataType
   pageContext: PageContext
   location: any
-};
+}
 
-export default function PostListTemplate({ data, location, pageContext }: Props) {
+export default function PostListTemplate({
+  data,
+  location,
+  pageContext,
+}: Props) {
   const siteTitle = data.site.siteMetadata?.title || `Title`
   const { humanPageNumber } = pageContext
 
   const breadcrumb: BreadcrumbListItem[] = [
-    { name: 'ホーム', current: false, url: '/' },
-    { name: '記事一覧', current: humanPageNumber === 1, url: '/posts/' },
+    { name: "ホーム", current: false, url: "/" },
+    { name: "記事一覧", current: humanPageNumber === 1, url: "/posts/" },
   ]
   if (humanPageNumber !== 1) {
     breadcrumb.push({ name: `${humanPageNumber} ページ`, current: true })
@@ -48,9 +52,9 @@ export default function PostListTemplate({ data, location, pageContext }: Props)
       <div className="full-wide-container">
         <BreadcrumbList items={breadcrumb} />
         <main>
-          <Paginator pathPrefix='/posts' context={pageContext} />
+          <Paginator pathPrefix="/posts" context={pageContext} />
           <PostCardList posts={data.allMarkdownRemark.nodes} />
-          <Paginator pathPrefix='/posts' context={pageContext} />
+          <Paginator pathPrefix="/posts" context={pageContext} />
         </main>
       </div>
     </Layout>
@@ -69,7 +73,7 @@ export const pageQuery = graphql`
       sort: { fields: [frontmatter___date], order: DESC }
       skip: $skip
       limit: $limit
-      ) {
+    ) {
       nodes {
         id
         excerpt(pruneLength: 120)

--- a/src/templates/post.tsx
+++ b/src/templates/post.tsx
@@ -45,62 +45,63 @@ type DataType = {
       heroImage: IGatsbyImageData
     }
   }
-};
+}
 
 type Props = {
   data: DataType
   location: any
-};
+}
 
 export default function BlogPostTemplate({ data, location }: Props) {
   const post = data.markdownRemark
   const siteTitle = data.site.siteMetadata?.title || `Title`
-  const { title } = post.frontmatter;
+  const { title } = post.frontmatter
 
-  const tags = post.frontmatter.tags;
-  const tagList = tags ? <TagList tags={tags} /> : null;
+  const tags = post.frontmatter.tags
+  const tagList = tags ? <TagList tags={tags} /> : null
 
-  const author = post.frontmatter.author;
-  const authorLink = author
-    ? <AuthorLink
-        github={author.id}
-        name={author.name}
-        avatarImage={post.frontmatter.avatarImage25}
-        />
-    : null;
-  const bio = author
-    ? <Bio
-        github={author.id}
-        name={author.name}
-        bio={author.bio}
-        avatarImage={post.frontmatter.avatarImage}
-        />
-    : null;
+  const author = post.frontmatter.author
+  const authorLink = author ? (
+    <AuthorLink
+      github={author.id}
+      name={author.name}
+      avatarImage={post.frontmatter.avatarImage25}
+    />
+  ) : null
+  const bio = author ? (
+    <Bio
+      github={author.id}
+      name={author.name}
+      bio={author.bio}
+      avatarImage={post.frontmatter.avatarImage}
+    />
+  ) : null
 
-  const { headings } = post;
-  const toc = headings?.length > 0
-    ? <PostToc headings={headings} page={post.fields.slug} />
-    : null;
+  const { headings } = post
+  const toc =
+    headings?.length > 0 ? (
+      <PostToc headings={headings} page={post.fields.slug} />
+    ) : null
 
   const breadcrumb: BreadcrumbListItem[] = [
-    { name: 'ホーム', current: false, url: '/' },
+    { name: "ホーム", current: false, url: "/" },
     { name: title, current: true },
   ]
 
   if (tags?.length) {
-    breadcrumb.splice(1, 0, { name: tags[0], url: tagNameToPageUrl(tags[0]), current: false });
+    breadcrumb.splice(1, 0, {
+      name: tags[0],
+      url: tagNameToPageUrl(tags[0]),
+      current: false,
+    })
   }
 
-  const heroImage = post.fields.heroImage && getImage(post.fields.heroImage);
-  const hero = (heroImage
-    ? <div className="post-hero">
-        <GatsbyImage
-          image={heroImage}
-          alt={title}
-          />
-      </div>
-    : null
-  );
+  const heroImage = post.fields.heroImage && getImage(post.fields.heroImage)
+  const hero = heroImage ? (
+    <div className="post-hero">
+      <GatsbyImage image={heroImage} alt={title} />
+    </div>
+  ) : null
 
   return (
     <Layout location={location} title={siteTitle}>
@@ -112,10 +113,7 @@ export default function BlogPostTemplate({ data, location }: Props) {
       <div className="main-container">
         <BreadcrumbList items={breadcrumb} />
         <main className={`post`}>
-          <article
-            itemScope
-            itemType="http://schema.org/Article"
-          >
+          <article itemScope itemType="http://schema.org/Article">
             <header>
               <h1 itemProp="headline">{title}</h1>
               {tagList}
@@ -131,20 +129,15 @@ export default function BlogPostTemplate({ data, location }: Props) {
             />
           </article>
         </main>
-        <div className="post-bio">
-          {bio}
-        </div>
-        <aside className="sidebar">
-          {toc}
-        </aside>
+        <div className="post-bio">{bio}</div>
+        <aside className="sidebar">{toc}</aside>
       </div>
     </Layout>
-  )}
+  )
+}
 
 export const pageQuery = graphql`
-  query BlogPostBySlug(
-    $id: String!
-  ) {
+  query BlogPostBySlug($id: String!) {
     site {
       siteMetadata {
         title

--- a/src/templates/tags.tsx
+++ b/src/templates/tags.tsx
@@ -1,13 +1,13 @@
 import React from "react"
 import { graphql } from "gatsby"
-import { PageContext as PageContextOrg } from "types/pagination";
+import { PageContext as PageContextOrg } from "types/pagination"
 
-import Layout from "components/layout";
-import Seo from "components/seo";
-import Paginator from "components/paginator";
-import BreadcrumbList, { BreadcrumbListItem } from "components/breadcrumb-list";
-import PostCardList from "components/post-card-list";
-import { PostSummary } from "components/post-card";
+import Layout from "components/layout"
+import Seo from "components/seo"
+import Paginator from "components/paginator"
+import BreadcrumbList, { BreadcrumbListItem } from "components/breadcrumb-list"
+import PostCardList from "components/post-card-list"
+import { PostSummary } from "components/post-card"
 
 type DataType = {
   site: {
@@ -20,7 +20,7 @@ type DataType = {
     totalCount: number
     edges: { node: PostSummary }[]
   }
-};
+}
 
 type PageContext = PageContextOrg & {
   tag: string
@@ -31,19 +31,19 @@ type Props = {
   data: DataType
   pageContext: PageContext
   location: any
-};
+}
 
 export default function TagPostList({ pageContext, data, location }: Props) {
   const { tag, basePath, humanPageNumber } = pageContext
   const { edges } = data.allMarkdownRemark
-  
+
   const { title } = data.site.siteMetadata
 
-  const posts = edges.map(x => x.node)
-  
+  const posts = edges.map((x) => x.node)
+
   const breadcrumb: BreadcrumbListItem[] = [
-    { name: 'ホーム', current: false, url: '/' },
-    { name: 'タグ一覧', current: false, url: '/tags/' },
+    { name: "ホーム", current: false, url: "/" },
+    { name: "タグ一覧", current: false, url: "/tags/" },
     { name: tag, current: humanPageNumber === 1, url: basePath },
   ]
   if (humanPageNumber !== 1) {
@@ -52,10 +52,7 @@ export default function TagPostList({ pageContext, data, location }: Props) {
 
   return (
     <Layout location={location} title={title}>
-      <Seo
-        title={title}
-        description={data.site.siteMetadata?.description}
-      />
+      <Seo title={title} description={data.site.siteMetadata?.description} />
       <div className="full-wide-container">
         <BreadcrumbList items={breadcrumb} />
         <main>
@@ -69,7 +66,7 @@ export default function TagPostList({ pageContext, data, location }: Props) {
 }
 
 export const pageQuery = graphql`
-  query($skip: Int!, $limit: Int!, $tag: String) {
+  query ($skip: Int!, $limit: Int!, $tag: String) {
     site {
       siteMetadata {
         title

--- a/src/utils/tag.tsx
+++ b/src/utils/tag.tsx
@@ -2,7 +2,7 @@ import { kebabCase } from "lodash"
 import slugs from "../data/tag-slug"
 
 export function tagNameToSlug(tagName: string) {
-  return tagName in slugs ? slugs[tagName] as string : kebabCase(tagName)
+  return tagName in slugs ? (slugs[tagName] as string) : kebabCase(tagName)
 }
 
 export function tagNameToPageUrl(tagName: string) {


### PR DESCRIPTION
いただいた意見を元にスタイルを調整しました。ついでに目次が寂しかったので、見出し追従を実装してみました。

調整した項目

- fix #10 
    - ダークモード時のリンク色調整
    - コードブロックの境界線追加
- fix #11
    - インラインコードのスタイル修正
    - 本文の行間調整
    - h2 のスタイル調整

![mv_20210914_180256](https://user-images.githubusercontent.com/13431810/133228762-5dd1d1d4-277b-4c16-9139-2f07fac15a55.gif)

![ss_20210914_180337](https://user-images.githubusercontent.com/13431810/133228834-734f3276-756c-482e-9201-ecac1adee92b.png)

![ss_20210914_180343](https://user-images.githubusercontent.com/13431810/133228838-9e506fe8-690d-4294-85c6-9657d5a7cac9.png)


