### PR TITLE
Fix some issues

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,7 +33,11 @@ const plugins = [
     options: {
       path: contentPath,
       name: `blog`,
-      ignore: [`${contentPath}/*.md`, `${contentPath}/.draft/**/*`],
+      ignore: [
+        `${contentPath}/*.md`,
+        `${contentPath}/.draft/**/*`,
+        `${contentPath}/.github/**/*`,
+      ],
     },
   },
   {

--- a/src/components/bio/index.tsx
+++ b/src/components/bio/index.tsx
@@ -53,7 +53,7 @@ const Bio = (props: Props) => {
             <span>{github}</span>
           </a>
         </div>
-        <p className={`${styles.bioText} bio-bio-text`}>{bio}</p>
+        <p className={`bio-bio-text`}>{bio}</p>
       </div>
     </div>
   )

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -133,6 +133,7 @@
   position: relative;
   background-color: var(--color-blockquote-bg);
   border-radius: var(--corner-radius);
+  font-size: var(--fontSize-0);
 }
 
 .post blockquote::before {
@@ -314,9 +315,14 @@
   border-radius: 0.25em;
   margin: 1em 0;
   padding: 0 1em;
+  font-size: var(--fontSize-0);
 }
 
 .gatsby-highlight pre[class*="language-"] {
+  padding: 0.5em 0;
+}
+
+.gatsby-highlight pre[class*="language-"] .line-numbers-rows {
   padding: 0.5em 0;
 }
 
@@ -330,6 +336,7 @@
 
 .gatsby-code-title span {
   font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  font-size: var(--fontSize-0);
   color: #eee;
   background: #777;
   border-top-left-radius: 0.25em;
@@ -339,7 +346,7 @@
 
 .gatsby-code-title + .gatsby-highlight {
   border-top-left-radius: 0;
-  margin-top: 0;
+  margin-top: -1px;
 }
 
 :not(pre) > code[class*="language-"] {


### PR DESCRIPTION
引用部分とソースコード部分のスタイルを調整しました。

フォントを本文と同じにしていたので、少し大きく、本文が読みづらく感じられたため、1サイズ下げました。また、行番号表示をつけたときに行番号と中身がずれてしまっていたので padding を調整しました。

左が変更前、右が変更後です。

![ss_20210927_152245](https://user-images.githubusercontent.com/13431810/134855234-257d5561-ee11-42f5-9eba-7f8b6250d329.png)

- - -

ついでに下記の修正も加えました。

- blog の .github ディレクトリが Gatsby のコンテンツソースになってしまっていたので、除外設定を追加しました
- bio コンポーネントで定義していていないクラス名を使っていたので、削除しました。