### PR TITLE
Add docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.dockerignore
+Dockerfile
+.cache
+.github
+public

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docker
 
 jobs:
   push_to_registry:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,25 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+      - docker
+
+jobs:
+  push_to_registry:
+    runs-on: ubuntu-latest
+    name: Push Docker image
+
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Push image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          repository: ${{ github.repository }}
+          tag_with_ref: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM node:14-slim
+EXPOSE 8000
+
+WORKDIR /app
+COPY . ./
+
+RUN npm ci && rm -rf node_modules/
+
+CMD npm ci -s && CONTENT_PATH=/content npx gatsby develop -H 0.0.0.0


### PR DESCRIPTION
執筆者が手元で実際の画面でプレビューを確認しながら執筆できるようにするため、 Docker のイメージを自動で作成するようにしました。

実行結果: [Add docker related files · mseninc/blog-gatsby@4ad50a2](https://github.com/mseninc/blog-gatsby/runs/3728635229?check_suite_focus=true)

Docker image は GitHub Container Registry に登録するようにしました。

[Package blog-gatsby](https://github.com/mseninc/blog-gatsby/pkgs/container/blog-gatsby)

```sh
docker run -d --name blog-gatsby -v $PWD:/content -p 8000:8000 ghcr.io/mseninc/blog-gatsby:docker
```

(`:docker` は今のこのブランチのタグがついているため)

blog をチェックアウトしたディレクトリで上記のように実行すると、イメージがダウンロードされ、バックグラウンドで gatsby develop が起動するはずです。 (npm install 等に少し時間がかかると思います)

しばらくすれば localhost:8000 でプレビューできるようになります。