### PR TITLE
プレビューで最新記事以外のページが削除されている不具合を修正

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,13 +1,14 @@
 const path = require("path")
 
 const contentPath = path.resolve(process.env.CONTENT_PATH || "content")
+const s3RemoveNonexistentObjects = `${process.env.S3_REMOVE_NONEXISTENT_OBJECTS}` === "true"
 
 console.debug(`CONTENT_PATH - ${contentPath}`)
 console.debug(`PATH_PREFIX - ${process.env.PATH_PREFIX}`)
 console.debug(`GA_TRACKING_ID - ${process.env.GA_TRACKING_ID}`)
 console.debug(`S3_BUCKET_NAME - ${process.env.S3_BUCKET_NAME}`)
 console.debug(`S3_REGION - ${process.env.S3_REGION}`)
-console.debug(`S3_REMOVE_NONEXISTENT_OBJECTS - ${process.env.S3_REMOVE_NONEXISTENT_OBJECTS}`)
+console.debug(`S3_REMOVE_NONEXISTENT_OBJECTS - ${s3RemoveNonexistentObjects}`)
 
 const {
   SITE_NAME,
@@ -170,7 +171,7 @@ const plugins = [
       bucketName: process.env.S3_BUCKET_NAME || "msen-blog-preview",
       region: process.env.S3_REGION || "ap-northeast-1",
       acl: null,
-      removeNonexistentObjects: process.env.S3_REMOVE_NONEXISTENT_OBJECTS,
+      removeNonexistentObjects: s3RemoveNonexistentObjects,
       // https://gatsby-plugin-s3.jari.io/recipes/with-cloudfront/
       protocol: siteAddress.protocol.slice(0, -1),
       hostname: siteAddress.hostname,


### PR DESCRIPTION
- fix #21

[gatsby-plugin-s3 | Gatsby](https://www.gatsbyjs.com/plugins/gatsby-plugin-s3/) で `removeNonexistentObjects` オプションを false にすると既存オブジェクトを削除しないようにできるので、プレビュー環境はそのように設定していたつもりでしたが、環境変数から渡ってきた `false` が文字列だったため、オプションが true として扱われていたようです。
（結果的に最新の記事以外は消える）

before 

![ss_20211002_133611](https://user-images.githubusercontent.com/13431810/135704153-9879d511-27dd-459c-aaca-60a18331c0a1.png)

after

![ss_20211002_135155](https://user-images.githubusercontent.com/13431810/135704154-2f40f503-2d71-46cd-8200-7aef17664d1c.png)

本番環境には影響はないはずですが、デプロイしてみないとわからないので、また不具合あれば修正します。