### PR TITLE
Fix tag for docker image

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,8 +1,6 @@
 name: Publish Docker image
 
 on:
-  workflow_dispatch:
-
   push:
     branches:
       - main
@@ -23,4 +21,4 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
           repository: ${{ github.repository }}
-          tags: latest,main
+          tags: latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,4 +24,3 @@ jobs:
           registry: ghcr.io
           repository: ${{ github.repository }}
           tags: latest,main
-          tag_with_ref: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,6 +1,8 @@
 name: Publish Docker image
 
 on:
+  workflow_dispatch:
+
   push:
     branches:
       - main
@@ -21,4 +23,5 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io
           repository: ${{ github.repository }}
+          tags: latest,main
           tag_with_ref: true


### PR DESCRIPTION
Docker を作成する Workflow でイメージに `latest` タグがつくようにしました。

[docker/build-push-action at releases/v1](https://github.com/docker/build-push-action/tree/releases/v1#tag_with_ref) の `tag_with_ref` オプションで `master` ブランチなら `latest` タグをつけてくれるんですが、 `main` ブランチだとつけてくれないので、明示的にタグを指定するようにしました。