### PR TITLE
Fix style

### DIFF
--- a/src/components/jump-button/index.module.css
+++ b/src/components/jump-button/index.module.css
@@ -34,6 +34,7 @@
   height: var(--icon-size);
   transform: rotate(225deg);
   transition: transform 1s;
+  backface-visibility: hidden;
 }
 
 .button.toBottom::before {

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -335,7 +335,7 @@
 }
 
 .gatsby-code-title span {
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
+  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", var(--fontFamily-sans), monospace;
   font-size: var(--fontSize-0);
   color: #eee;
   background: #777;
@@ -354,6 +354,7 @@
   color: inherit;
   background-color: var(--color-inline-code-bg);
   text-shadow: none;
+  letter-spacing: var(--letterSpacing-normal);
 }
 
 

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -112,7 +112,7 @@
   --color-top-page-hero-copy: white;
   --color-post-card-description-bg: #e6f3ff;
   --color-inline-code-bg: #215aa012;
-  --color-line-marker-1: #eecc0033;
+  --color-line-marker-1: #eecc0066;
   --color-line-marker-2: #00cc0033;
   --color-blockquote-bg: #0000000c;
   --color-table-border: #00000033;
@@ -155,7 +155,7 @@ body.theme-dark {
   --color-top-page-hero-copy: white;
   --color-post-card-description-bg: #2e384d;
   --color-inline-code-bg: #ffffff33;
-  --color-line-marker-1: #eecc0033;
+  --color-line-marker-1: #ffdd0033;
   --color-line-marker-2: #00cc0033;
   --color-blockquote-bg: #ffffff1c;
   --color-table-border: #ffffff44;


### PR DESCRIPTION


いくつかスタイルを修正しました。

### Chrome でページトップ・ボトム移動ボタンの描画がおかしい問題

- fix #24 

before:
![image](https://user-images.githubusercontent.com/13431810/151899359-66aa386a-1d15-4e97-b00b-85e88e697f8d.png)
after:
![mv_20220201_102935](https://user-images.githubusercontent.com/13431810/151899945-ca4df1d9-df46-464e-8f7f-e4080205de1f.gif)

### その他スタイル微修正

![ss_20220201_112219](https://user-images.githubusercontent.com/13431810/151904575-84a6fead-cbde-4cd6-b677-07ede95f24ce.png)

1. インラインコードの `letter-spacing` 調整
2. ライトテーマ時のラインマーカーの色を微修正
3. コードブロックタイトルの日本語フォントを修正