### PR TITLE
スタイル修正

### DIFF
--- a/src/components/post-toc/index.tsx
+++ b/src/components/post-toc/index.tsx
@@ -41,6 +41,7 @@ export default function PostToc(props: Props) {
   }, [activeAnchor])
 
   function createHeading(h: Heading) {
+    const text = h.value.replace(/(<([^>]+)>)/gi, '');
     return (
       <li
         key={`post-toc-item-${h.id}`}
@@ -48,7 +49,7 @@ export default function PostToc(props: Props) {
           styles[`depth${h.depth - 1}`]
         } ${h.id === activeAnchor ? "post-toc-item-active" : ""}`}
       >
-        <AnchorLink to={`${props.page}#${h.id}`}>{h.value}</AnchorLink>
+        <AnchorLink to={`${props.page}#${h.id}`}>{text}</AnchorLink>
       </li>
     )
   }

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -311,10 +311,10 @@
 
 .gatsby-highlight {
   background-color: #272822;
-  border: solid 1px rgba(255, 255, 255, 0.2);
+  border: 0;
   border-radius: 0.25em;
   margin: 1em 0;
-  padding: 0 1em;
+  padding: 0.5em 1em;
   font-size: var(--fontSize-0);
 }
 
@@ -346,7 +346,7 @@
 
 .gatsby-code-title + .gatsby-highlight {
   border-top-left-radius: 0;
-  margin-top: -1px;
+  margin-top: 0;
 }
 
 :not(pre) > code[class*="language-"] {
@@ -355,6 +355,8 @@
   background-color: var(--color-inline-code-bg);
   text-shadow: none;
   letter-spacing: var(--letterSpacing-normal);
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 

--- a/src/styles/post.css
+++ b/src/styles/post.css
@@ -311,7 +311,7 @@
 
 .gatsby-highlight {
   background-color: #272822;
-  border: 0;
+  border: solid 1px rgba(255, 255, 255, 0.2);
   border-radius: 0.25em;
   margin: 1em 0;
   padding: 0.5em 1em;

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -43,20 +43,8 @@
   --spacing-32: 8rem;
 
   --fontFamily-sans:
-  "Helvetica Neue",
-  "Helvetica",
-  "Arial",
-  "BIZ UDPGothic",
-  "ヒラギノ角ゴ Pro W3",
-  "Yu Gothic Medium",
-  "游ゴシック Medium",
-  YuGothic,
-  "游ゴシック体",
-  "Hiragino Sans",
-  "Hiragino Kaku Gothic ProN",
-  "Yu Gothic",
-  "Meiryo",
-  "メイリオ",
+  "Noto Sans JP",
+  "Noto Sans CJK",
   sans-serif;
   --font-body: var(--fontFamily-sans);
   --font-heading: var(--fontFamily-sans);
@@ -72,7 +60,7 @@
   --lineHeight-none: 1;
   --lineHeight-tight: 1.2;
   --lineHeight-normal: 1.5;
-  --lineHeight-relaxed: 1.9;
+  --lineHeight-relaxed: 1.75;
 
   --letterSpacing-normal: normal;
   --letterSpacing-relaxed: 0.05em;


### PR DESCRIPTION
ブログの記事スタイルを若干修正しました。

![ss_20220519_084653](https://user-images.githubusercontent.com/13431810/169174519-c725dbfc-3265-4438-b263-00745657ddb5.png)

1. 目次に含まれる HTML タグを除去
2. 記事のフォントを "Noto Sans" のみ指定し、なければユーザー環境のフォントを使用するように変更
4. 記事本文の行間を微妙に削減 (1.9 → 1.75)
5. インラインコードであふれた部分が表示できていなかったのを修正
6. コードブロックのスタイルを微修正