### PR TITLE
Web フォント読み込みを省略

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -186,19 +186,6 @@ const plugins = [
       hostname: siteAddress.hostname,
     },
   },
-  {
-    resolve: `gatsby-omni-font-loader`,
-    options: {
-      enableListener: true,
-      preconnect: [`https://fonts.googleapis.com`, `https://fonts.gstatic.com`],
-      web: [
-        {
-          name: `Noto Sans JP`,
-          file: `https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;600&display=swap`,
-        },
-      ],
-    },
-  },
 ]
 
 if (process.env.GA_TRACKING_ID) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "gatsby": "^5.3.3",
         "gatsby-awesome-pagination": "^0.3.8",
         "gatsby-link": "^5.3.1",
-        "gatsby-omni-font-loader": "^2.0.2",
         "gatsby-plugin-anchor-links": "^1.2.1",
         "gatsby-plugin-canonical-urls": "^5.3.0",
         "gatsby-plugin-feed": "^5.3.1",
@@ -10124,15 +10123,6 @@
         "@gatsbyjs/reach-router": "^2.0.0",
         "react": "^18.0.0 || ^0.0.0",
         "react-dom": "^18.0.0 || ^0.0.0"
-      }
-    },
-    "node_modules/gatsby-omni-font-loader": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/gatsby-omni-font-loader/-/gatsby-omni-font-loader-2.0.2.tgz",
-      "integrity": "sha512-Bp6truuUwbDRHWtL+u/lUvMsAT5ipO45LNJgqNdOzTUGw3GB7dw8k4RHDtpxwFTgacdk25kH8aOYfh460jJYCQ==",
-      "peerDependencies": {
-        "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0",
-        "react-helmet": ">=6.0.0"
       }
     },
     "node_modules/gatsby-page-utils": {
@@ -29339,12 +29329,6 @@
         "gatsby-page-utils": "^3.3.1",
         "prop-types": "^15.8.1"
       }
-    },
-    "gatsby-omni-font-loader": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/gatsby-omni-font-loader/-/gatsby-omni-font-loader-2.0.2.tgz",
-      "integrity": "sha512-Bp6truuUwbDRHWtL+u/lUvMsAT5ipO45LNJgqNdOzTUGw3GB7dw8k4RHDtpxwFTgacdk25kH8aOYfh460jJYCQ==",
-      "requires": {}
     },
     "gatsby-page-utils": {
       "version": "3.3.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "gatsby": "^5.3.3",
     "gatsby-awesome-pagination": "^0.3.8",
     "gatsby-link": "^5.3.1",
-    "gatsby-omni-font-loader": "^2.0.2",
     "gatsby-plugin-anchor-links": "^1.2.1",
     "gatsby-plugin-canonical-urls": "^5.3.0",
     "gatsby-plugin-feed": "^5.3.1",

--- a/src/components/layout.tsx
+++ b/src/components/layout.tsx
@@ -1,10 +1,10 @@
-import * as React from "react"
 import { graphql, Link, useStaticQuery } from "gatsby"
 import { StaticImage } from "gatsby-plugin-image"
+import * as React from "react"
 
 import JumpButton from "./jump-button"
-import ThemeSwitcher from "./theme-switcher"
 import PageFooter from "./page-footer"
+import ThemeSwitcher from "./theme-switcher"
 
 type Props = {
   location: { pathname: string }

--- a/src/components/web-font/index.tsx
+++ b/src/components/web-font/index.tsx
@@ -1,0 +1,34 @@
+import React from "react"
+import { Helmet } from "react-helmet"
+
+// NOTE: [Webフォント読み込み戦略（2021年） - MOL](https://t32k.me/mol/log/optimize-webfont-loading/)
+
+const webFontUrl =
+  "https://fonts.googleapis.com/css2?family=Josefin+Sans&display=swap"
+
+export default function WebFont() {
+  return (
+    <>
+      <Helmet>
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="true"
+        />
+        <link rel="preload" as="style" href={webFontUrl} />
+        <link
+          rel="stylesheet"
+          href={webFontUrl}
+          media="print"
+          onLoad="this.media='all'"
+        />
+        <noscript>
+          {`<link
+            rel="stylesheet"
+            href="${webFontUrl}"
+          />`}
+        </noscript>
+      </Helmet>
+    </>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { graphql } from "gatsby"
 import * as React from "react"
-import { Helmet } from "react-helmet"
 
 import ClientOnly from "components/client-only"
 import Layout from "components/layout"
@@ -10,6 +9,7 @@ import SearchBox from "components/search-box"
 import Seo from "components/seo"
 import TopPageHeading from "components/top-page-heading"
 import TopPageHero from "components/top-page-hero"
+import WebFont from "components/web-font"
 import { tagNameToPageUrl } from "utils/tag"
 
 const featuredTags = [
@@ -93,18 +93,7 @@ export default function BlogIndex({ data, location }: Props) {
 
   return (
     <Layout location={location} title={siteTitle}>
-      <Helmet>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="crossOrigin"
-        />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Josefin+Sans&display=swap"
-          rel="stylesheet"
-        />
-      </Helmet>
+      <WebFont />
       <Seo />
       <TopPageHero />
       <div className="global-root-group search-group">

--- a/src/styles/search-box.css
+++ b/src/styles/search-box.css
@@ -6,8 +6,12 @@
   padding: var(--spacing-2) var(--spacing-0);
 }
 
-.global-root-group > .global-wrapper {
+/* 表示時にコンテナーサイズが変化するためサイズを固定 */
+.global-root-group.search-group > .global-wrapper {
   padding: var(--spacing-0);
+  height: 64px;
+  display: grid;
+  align-items: center;
 }
 
 /* gsc コンテナー */
@@ -15,6 +19,20 @@
   background-color: transparent !important;
   border-color: transparent !important;
   font-family: revert !important; /* 本文フォントに戻す */
+
+  /* 突然表示されるのを緩和するためアニメーション */
+  animation-name: searchBoxFadeIn;
+  animation-duration: 2s;
+  animation-fill-mode: forwards;
+  opacity: 0;
+}
+@keyframes searchBoxFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 form.gsc-search-box {

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -42,7 +42,7 @@
   --spacing-24: 6rem;
   --spacing-32: 8rem;
 
-  --fontFamily-sans: "Noto Sans JP", "Noto Sans CJK", sans-serif;
+  --fontFamily-sans: "Noto Sans JP", "Noto Sans CJK", "Meiryo UI", sans-serif;
   --font-body: var(--fontFamily-sans);
   --font-heading: var(--fontFamily-sans);
   --fontWeight-normal: 400;


### PR DESCRIPTION
Page Insights で計測したところ、やはり Web フォントの読み込みで遅延が発生しているため、使用しないように変更しました。

![ss_20221223_094745](https://user-images.githubusercontent.com/13431810/209260261-071cc6dd-6b9c-4665-bd98-b93b9e054912.png)


[ステージング](https://mseeeen-staging.msen.dev/) は使用しない状態になっています。

また、トップページの検索ボックスで、読み込み時に高さが変わって急に現れるため、事前に高さを確保し、フェードインするようにしました。

本番とステージングで比べるとわかりやすいと思います。